### PR TITLE
Typo error in the main.js example

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -417,7 +417,7 @@ main();</code></pre>
       <div class="example">
         <p><strong>🛠 main.js</strong></p>
         <pre class="hljs"><code><span class="hljs-comment">// import a CSS module</span>
-<span class="hljs-keyword">import</span> classes <span class="hljs-keyword">from</span> <span class="hljs-string">'./index.css'</span>;
+<span class="hljs-keyword">import</span> classes <span class="hljs-keyword">from</span> <span class="hljs-string">'./main.css'</span>;
 
 <span class="hljs-keyword">export</span> <span class="hljs-keyword">default</span> () =&gt; {
   <span class="hljs-built_in">console</span>.log(classes.main);


### PR DESCRIPTION
The `import` statement is trying to get the `index.css` file but the name of the file in the example is `main.css`