### PR TITLE
Use recommended way to specify Autoprefixer’ browsers

### DIFF
--- a/src/docs/transforms.md
+++ b/src/docs/transforms.md
@@ -39,13 +39,20 @@ Then, create a `.postcssrc`:
   "modules": true,
   "plugins": {
     "autoprefixer": {
-      "browsers": ["last 2 versions"]
+      "grid" true
     }
   }
 }
 ```
 
 Plugins are specified in the `plugins` object as keys, and options are defined using object values. If there are no options for a plugin, just set it to `true` instead.
+
+Target browsers for Autoprefixer, cssnext and other tools can be specified in `.browserslistrc` file:
+
+```
+> 1%
+last 2 versions
+```
 
 CSS Modules are enabled slightly differently using the a top-level `modules` key. This is because Parcel needs to have special support for CSS Modules since they export an object to be included in the JavaScript bundle as well. Note that you still need to install `postcss-modules` in your project.
 


### PR DESCRIPTION
@devongovett Wow. Amazing project! Also focusing on PostCSS is neat =^_^=.

Small fix for `browsers` option. We don’t recommend to use them, since not only Autoprefixer need target browsers. ESLint/Stylelint plugins, cssnano, cssnext, next `babel-preset-env` 2.0 could read browsers from one config file: [.browserslistrc](https://github.com/ai/browserslist).

We recommend only this way. Seems like you wrote this option to show options syntax. So I changed the option to `grid`.