### PR TITLE
Fix minor typos encountered while reading

### DIFF
--- a/src/docs/how_it_works.md
+++ b/src/docs/how_it_works.md
@@ -8,7 +8,7 @@ Parcel takes as input a single entry asset, which could be any type: a JS file, 
 
 ### 2. Constructing the Bundle Tree
 
-Once the asset tree as been constructed, the assets are placed into a bundle tree. A bundle is created for the entry asset, and child bundles are created for dynamic `import()`s, which cause code splitting to occur.
+Once the asset tree has been constructed, the assets are placed into a bundle tree. A bundle is created for the entry asset, and child bundles are created for dynamic `import()`s, which cause code splitting to occur.
 
 Sibling bundles are created when assets of a different type are imported, for example if you imported a CSS file from JavaScript, it would be placed into a sibling bundle to the corresponding JavaScript.
 

--- a/src/docs/packagers.md
+++ b/src/docs/packagers.md
@@ -25,9 +25,9 @@ class MyPackager extends Packager {
 }
 ```
 
-## Registering an Asset Type
+## Registering a Packager
 
-You can register your asset type with a bundler using the `addPackager` method. It accepts a file type to register, and the path to your packager module.
+You can register your packager with a bundler using the `addPackager` method. It accepts a file type to register, and the path to your packager module.
 
 ```javascript
 const Bundler = require('parcel-bundler');


### PR DESCRIPTION
As I was reading the great documentation, I encountered a few typos/copy paste issues. I fixed these minor issues according to my native speaker ear and programmer gut.