### PR TITLE
Added missing colon in the .postcssrc JSON

### DIFF
--- a/src/docs/transforms.md
+++ b/src/docs/transforms.md
@@ -39,7 +39,7 @@ Then, create a `.postcssrc`:
   "modules": true,
   "plugins": {
     "autoprefixer": {
-      "grid" true
+      "grid": true
     }
   }
 }


### PR DESCRIPTION
Updated the https://parceljs.org/transforms.html#postcss to have the missing colon in the .postcssrc sample code.