### PR TITLE
Adds SCSS documentation to Assets

### DIFF
--- a/src/docs/assets.md
+++ b/src/docs/assets.md
@@ -55,6 +55,17 @@ CSS assets can be imported from a JavaScript or HTML file, and can contain depen
 
 In addition to plain CSS, other compile-to-CSS languages like LESS, SASS, and Stylus are also supported, and work the same way.
 
+## SCSS
+SCSS compilation needs `node-sass` module. To install it with npm:
+```
+npm install node-sass
+```
+Once you have `node-sass` installed you can import SCSS files from JavaScript files.
+```
+import './custom.scss'
+```
+Dependencies in the SCSS files can be used with the `@import` statements.
+
 ## HTML
 
 HTML assets are often the entry file that you provide to Parcel, but can also be referenced by JavaScript files, e.g. to provide links to other pages. URLs to scripts, styles, media, and other HTML files are extracted and compiled as described above. The references are rewritten in the HTML so that they link to the correct output files. All filenames should be relative to the current HTML file.


### PR DESCRIPTION
# What is the problem this PR solves?
SCSS was not documented on the website. Users had problems integrating Parcel with SCSS.
Example issue: [[Question] Can I use SCSS with parcel? #60](https://github.com/parcel-bundler/parcel/issues/60)

# What is the solution?
Add SCSS documentation to the website

# How should this be manually tested?
Run the website, or:
I add a screenshot here for convenience.
<img width="742" alt="screen shot 2017-12-13 at 19 19 19" src="https://user-images.githubusercontent.com/2179258/33955320-65301a64-e03b-11e7-8a0b-a0fc277353bc.png">

# Risk of this PR
Misleading documentation hurts users. I created an example project following the new documentation and it works. *Risk is negligible*.
Example project: [Parcel bundler SCSS example](https://github.com/gulyasm/parcel-scss-example)