### PR TITLE
Document edge case with HMR for non-JS

### DIFF
--- a/src/i18n/en/docs/hmr.md
+++ b/src/i18n/en/docs/hmr.md
@@ -17,3 +17,5 @@ if (module.hot) {
   });
 }
 ```
+
+Note: HMR will be available in the application if it contains at least one JS file. Parcel will not inject the necessary JS code in your page otherwise.


### PR DESCRIPTION
... I think it could help further troubleshooting!

Feel free to reword it as you'd prefer of course.

The basic thing is that without any JS script included in the HTML Parcel will not inject its script containing the HMRClient initialization. I think it can be considered as a feature, but if you think it would be better to "fix" this behavior to inject a new script tag do not hesitate to close this PR and create an issue in the main repo. 