### PR TITLE
fix language selector alignment

### DIFF
--- a/src/assets/home.css
+++ b/src/assets/home.css
@@ -143,7 +143,6 @@ header .links a:hover {
   padding: 0 10px;
   border-radius: 4px;
   font-size: 22px;
-  vertical-align: middle;
 }
 
 .language-dropdown ul {

--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -56,7 +56,6 @@ header .links a {
   padding: 0 10px;
   border-radius: 4px;
   font-size: 22px;
-  vertical-align: middle;
   margin-right: 20px;
 }
 


### PR DESCRIPTION
remove vertical-align in language-dropdown

before
index page
![before1](https://user-images.githubusercontent.com/6044471/34034965-d72dd6cc-e1c3-11e7-9cd9-7ba35b90c208.png)
documentation page
![before2](https://user-images.githubusercontent.com/6044471/34034967-d758af46-e1c3-11e7-921d-85d05c0db93d.png)

after
index page
![after1](https://user-images.githubusercontent.com/6044471/34034977-db93bc2c-e1c3-11e7-9ba2-0414fd87ddbb.png)
documentation page
![after2](https://user-images.githubusercontent.com/6044471/34034978-dbbe6224-e1c3-11e7-8da5-a3f0157d35e8.png)
