### PR TITLE
fix: typo in polish subheader

### DIFF
--- a/src/i18n/pl/index.html
+++ b/src/i18n/pl/index.html
@@ -21,7 +21,7 @@
 <body>
   <header>
     <img class="logo" src="assets/logo.svg" alt="Parcel">
-    <h2>Oszałamiająco szybki, nie wymagający konfiguracji program tworzący pakiety</h2>
+    <h2>Oszałamiająco szybki, niewymagający konfiguracji program tworzący pakiety</h2>
     <div class="parcel">
       <img src="assets/parcel-back.png" srcset="assets/parcel-back@2x.png 2x, assets/parcel-back@3x.png 3x">
       <div class="icons"></div>


### PR DESCRIPTION
Polish subheader has a typo.

You could trust me about this because I used to be a full-time printed media journalist for a year but perhaps a dictionary link will be even better: https://sjp.pwn.pl/sjp/;2490229
  