### PR TITLE
ru-RU: remove an odd hyphen

### DIFF
--- a/src/i18n/ru/index.html
+++ b/src/i18n/ru/index.html
@@ -6,7 +6,7 @@
   <meta property="og:title" content="📦 Parcel" />
   <meta property="og:url" content="https://parceljs.org/" />
   <meta property="og:type" content="website" />
-  <meta property="og:description" content="Молниеносно-быстрый упаковщик для веб-приложений без настроек" />
+  <meta property="og:description" content="Молниеносно быстрый упаковщик для веб-приложений без настроек" />
   <title>📦 Parcel</title>
   <link type="text/css" rel="stylesheet" href="assets/home.css"/>
   <link type="text/css" rel="stylesheet" href="assets/hljs-github.min.css"/>
@@ -21,7 +21,7 @@
 <body>
   <header>
     <img class="logo" src="assets/logo.svg" alt="Parcel">
-    <h2>Молниеносно-быстрый упаковщик для веб-приложений без настроек</h2>
+    <h2>Молниеносно быстрый упаковщик для веб-приложений без настроек</h2>
     <div class="parcel">
       <img src="assets/parcel-back.png" srcset="assets/parcel-back@2x.png 2x, assets/parcel-back@3x.png 3x">
       <div class="icons"></div>
@@ -49,7 +49,7 @@
   <main>
     <div class="features">
       <section>
-        <h3>🚀 Молниеносно-быстрый</h3>
+        <h3>🚀 Молниеносно быстрый</h3>
         <p>Parcel использует воркеры для включения многоядерной компиляции и имеет кэш файловой системы для быстрых пересборки даже после перезапуска.</p>
       </section>
       <section>


### PR DESCRIPTION
No hyphen is required in case of “молниеносно быстрый”. See http://therules.ru/hyphen-adjectives/#81.