### PR TITLE
Update `now` to ^9.2.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 .idea/
 yarn.lock
 .DS_Store
+yarn-error.log

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "markdown-styles": "^3.1.10",
-    "now": "^8.3.10",
+    "now": "^9.2.7",
     "now-travis": "^1.2.0",
     "npm-run-all": "^4.1.1"
   },


### PR DESCRIPTION
Now recently flipped their downloads to pull from GitHub instead of their CDN. The `8.5.4` download is now failing through their CDN (gzip decompression, anyway). Going ahead and upgrading.

Related:
https://github.com/zeit/now-cli/pull/1089
https://github.com/zeit/now-cli-releases/pull/4

closes #97 