### PR TITLE
Add alias for website in Spanish

### DIFF
--- a/now.json
+++ b/now.json
@@ -2,6 +2,7 @@
   "alias": [
     "parceljs.org",
     "en.parceljs.org",
+    "es.parceljs.org",
     "ko.parceljs.org",
     "pl.parceljs.org",
     "pt.parceljs.org",


### PR DESCRIPTION
This complements #87 with the fix to add the alias for the Spanish website URL.