### PR TITLE
Change color of language dropdown items

### DIFF
--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -79,6 +79,7 @@ header .links a {
 }
 
 .language-dropdown li a {
+  color: #21374B;
   padding: 0;
 }
 


### PR DESCRIPTION
The old language dropdown menu was unreadable due to low contrast between the text and the background: 

![Old Language Dropdown](http://cubeupload.com/im/FNOrjK.png)

I changed the color of the text to match the header:

![New Language Dropdown](https://imgur.com/a/4T5Nc)