### PR TITLE
update babel part in transforms

### DIFF
--- a/src/i18n/en/docs/recipes.md
+++ b/src/i18n/en/docs/recipes.md
@@ -37,7 +37,6 @@ First we need to install the dependencies for Preact.
 npm install --save preact
 npm install --save preact-compat
 npm install --save-dev parcel-bundler
-npm install --save-dev babel-preset-env
 npm install --save-dev babel-preset-preact
 ```
 
@@ -47,7 +46,6 @@ npm install --save-dev babel-preset-preact
 yarn add preact
 yarn add preact-compat
 yarn add --dev parcel-bundler
-yarn add --dev babel-preset-env
 yarn add --dev babel-preset-preact
 ```
 
@@ -56,7 +54,9 @@ Then make sure the following Babel config is present.
 ```javascript
 // .babelrc
 {
-  "presets": ["env", "preact"]
+  "presets": [
+    "preact"
+  ]
 }
 ```
 

--- a/src/i18n/en/docs/transforms.md
+++ b/src/i18n/en/docs/transforms.md
@@ -28,11 +28,11 @@ Then, create a `.babelrc`:
 
 Parcel transpiles your code with `babel-preset-env` by default, this is to transpile every module both internal (local requires) and external (node_modules) to match the defined target.
 
-For the `browser` target it utilises [browserlist](https://github.com/browserslist/browserslist), the target browserlist can be defined in multiple locations inside `package.json` (`engines.browsers` or `browserslist`) or an external config (`browserslist` or `.browserslistrc`).
+For the `browser` target it utilises [browserlist](https://github.com/browserslist/browserslist), the target browserlist can be defined in multiple locations inside `package.json` (`engines.browsers` or `browserslist`) or inside a configuration file (`browserslist` or `.browserslistrc`).
 
 The browserlist target defaults to: `> 0.25%` (Meaning, support every browser that has 0.25% or more of the total amount of active web users)
 
-For the `node` target it just utilises the `engines.node` defined in `package.json`, this default to *node 8*.
+For the `node` target, Parcel uses the `engines.node` defined in `package.json`, this default to *node 8*.
 
 ## PostCSS
 

--- a/src/i18n/en/docs/transforms.md
+++ b/src/i18n/en/docs/transforms.md
@@ -11,16 +11,28 @@ This even works in third-party `node_modules`: if a configuration file is publis
 Install presets and plugins in your app:
 
 ```bash
-yarn add babel-preset-env
+yarn add babel-preset-react
 ```
 
 Then, create a `.babelrc`:
 
 ```json
 {
-  "presets": ["env"]
+  "presets": [
+    "react"
+  ]
 }
 ```
+
+### Default babel transforms
+
+Parcel install and transpiles your code with `babel-preset-env` by default, this is to transpile every module both internal (local requires) and external (node_modules) to match the defined target.
+
+For the `browser` target it utilises [browserlist](https://github.com/browserslist/browserslist), the target browserlist can be defined in multiple locations inside `package.json` (`engines.browsers` or `browserslist`) or an external config (`browserslist` or `.browserslistrc`).
+
+The browserlist target defaults to: `> 0.25%` (Meaning, support every browser that has 0.25% or more of the total amount of active web users)
+
+For the `node` target it just utilises the `engines.node` defined in `package.json`, this default to *node 8*.
 
 ## PostCSS
 

--- a/src/i18n/en/docs/transforms.md
+++ b/src/i18n/en/docs/transforms.md
@@ -28,7 +28,7 @@ Then, create a `.babelrc`:
 
 Parcel transpiles your code with `babel-preset-env` by default, this is to transpile every module both internal (local requires) and external (node_modules) to match the defined target.
 
-For the `browser` target it utilises [browserlist](https://github.com/browserslist/browserslist), the target browserlist can be defined in multiple locations inside `package.json` (`engines.browsers` or `browserslist`) or inside a configuration file (`browserslist` or `.browserslistrc`).
+For the `browser` target it utilises [browserlist](https://github.com/browserslist/browserslist), the target browserlist can be defined in `package.json` (`engines.browsers` or `browserslist`) or using a configuration file (`browserslist` or `.browserslistrc`).
 
 The browserlist target defaults to: `> 0.25%` (Meaning, support every browser that has 0.25% or more of the total amount of active web users)
 

--- a/src/i18n/en/docs/transforms.md
+++ b/src/i18n/en/docs/transforms.md
@@ -26,7 +26,7 @@ Then, create a `.babelrc`:
 
 ### Default babel transforms
 
-Parcel install and transpiles your code with `babel-preset-env` by default, this is to transpile every module both internal (local requires) and external (node_modules) to match the defined target.
+Parcel transpiles your code with `babel-preset-env` by default, this is to transpile every module both internal (local requires) and external (node_modules) to match the defined target.
 
 For the `browser` target it utilises [browserlist](https://github.com/browserslist/browserslist), the target browserlist can be defined in multiple locations inside `package.json` (`engines.browsers` or `browserslist`) or an external config (`browserslist` or `.browserslistrc`).
 


### PR DESCRIPTION
Updates babel transforms doc to include defaults and basic introduction to how we use `babel-preset-env`

This also removes the redundant `babel-preset-env` from Preact example

Closes #175