### PR TITLE
Add filename strategy doc

### DIFF
--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -201,6 +201,11 @@ img { border: 0; -ms-interpolation-mode: bicubic; vertical-align: middle; }
 table { border-collapse: collapse; border-spacing: 0; }
 td { vertical-align: top; }
 
+td, th {
+  border: 1px solid #999;
+  padding: .5rem 1rem;
+}
+
 @media only screen and (max-width: 952px) {
   .content {
     flex-direction: column;

--- a/src/i18n/en/docs/production.md
+++ b/src/i18n/en/docs/production.md
@@ -23,9 +23,9 @@ Parcel follows the following table, when it comes to naming bundles. (Entrypoint
 | JavaScript | Regular require/import |  |  |
 | JavaScript | Dynamic import | ✅  |    |
 | JavaScript | Service worker | ✅  | ✅ |
-| HTML | iframe src | ✅ | ✅ |
-| HTML | a href | ✅ | ✅ |
+| HTML | iframe | ✅ | ✅ |
+| HTML | anchor link | ✅ | ✅ |
 | CSS | import | ✅ |  |
-| Raw (Images, text files, ...) | Import/Require/html link/... | ✅ |  |
+| Raw (Images, text files, ...) | Import/Require/... | ✅ |  |
 
 The file hash follows the following naming pattern: `<directory name>-<hash>.<extension>`

--- a/src/i18n/en/docs/production.md
+++ b/src/i18n/en/docs/production.md
@@ -18,9 +18,9 @@ To allow setting very aggresive caching rules to your cdn, for optimal performan
 
 Parcel follows the following table, when it comes to naming bundles. (Entrypoints are never hashed)
 
-| Language | Type | Content hashed |
+| Bundle Type | Type | Content hashed |
 | ---:| --- |:---:|:---:|
-| All | Entrypoint            | ❌ |
+| Any | Entrypoint            | ❌ |
 | JavaScript | `<script>`     | ✅ |
 | JavaScript | Dynamic import | ❌ |
 | JavaScript | Service worker | ❌ |

--- a/src/i18n/en/docs/production.md
+++ b/src/i18n/en/docs/production.md
@@ -6,6 +6,26 @@ When it comes time to bundle your application for production, you can use Parcel
 parcel build entry.js
 ```
 
+## Optimisations
+
 This disables watch mode and hot module replacement so it will only build once. It also enables the minifier for all output bundles to reduce file size. The minifiers used by Parcel are [terser](https://github.com/fabiosantoscode/terser) for JavaScript, [cssnano](http://cssnano.co) for CSS, and [htmlnano](https://github.com/posthtml/htmlnano) for HTML.
 
 Enabling production mode also sets the `NODE_ENV=production` environment variable. Large libraries like React have development only debugging features which are disabled by setting this environment variable, which results in smaller and faster builds for production.
+
+## File naming strategy
+
+To allow setting very aggresive caching rules to your cdn, for optimal performance and efficiency Parcel hashes the file names of most assets (according to whether the bundle should have a readable/rememberable name or not, mainly for SEO).
+
+Parcel follows the following table, when it comes to naming bundles. (Entrypoints are never hashed)
+
+| Language | Type | Content hashed | Public URL (maintains original name) |
+| ---:| --- |:---:|:---:|
+| JavaScript | Regular require/import |  |  |
+| JavaScript | Dynamic import | ✅  |    |
+| JavaScript | Service worker | ✅  | ✅ |
+| HTML | iframe src | ✅ | ✅ |
+| HTML | a href | ✅ | ✅ |
+| CSS | import | ✅ |  |
+| Raw (Images, text files, ...) | Import/Require/html link/... | ✅ |  |
+
+The file hash follows the following naming pattern: `<directory name>-<hash>.<extension>`

--- a/src/i18n/en/docs/production.md
+++ b/src/i18n/en/docs/production.md
@@ -14,7 +14,7 @@ Enabling production mode also sets the `NODE_ENV=production` environment variabl
 
 ## File naming strategy
 
-To allow setting very aggresive caching rules to your cdn, for optimal performance and efficiency Parcel hashes the file names of most assets (according to whether the bundle should have a readable/rememberable name or not, mainly for SEO).
+To allow setting very aggresive caching rules to your cdn, for optimal performance and efficiency, Parcel hashes the file names of most bundles (according to whether the bundle should have a readable/rememberable name or not, mainly for SEO).
 
 Parcel follows the following table, when it comes to naming bundles. (Entrypoints are never hashed)
 

--- a/src/i18n/en/docs/production.md
+++ b/src/i18n/en/docs/production.md
@@ -18,14 +18,14 @@ To allow setting very aggresive caching rules to your cdn, for optimal performan
 
 Parcel follows the following table, when it comes to naming bundles. (Entrypoints are never hashed)
 
-| Language | Type | Content hashed | Public URL (maintains original name) |
+| Language | Type | Content hashed |
 | ---:| --- |:---:|:---:|
-| JavaScript | Regular require/import |  |  |
-| JavaScript | Dynamic import | ✅  |    |
-| JavaScript | Service worker | ✅  | ✅ |
-| HTML | iframe | ✅ | ✅ |
-| HTML | anchor link | ✅ | ✅ |
-| CSS | import | ✅ |  |
-| Raw (Images, text files, ...) | Import/Require/... | ✅ |  |
+| All | Entrypoint            | ❌ |
+| JavaScript | `<script>`     | ✅ |
+| JavaScript | Dynamic import | ❌ |
+| JavaScript | Service worker | ❌ |
+| HTML | iframe               | ❌ |
+| HTML | anchor link          | ❌ |
+| Raw (Images, text files, ...) | Import/Require/... | ✅ |
 
 The file hash follows the following naming pattern: `<directory name>-<hash>.<extension>`


### PR DESCRIPTION
Adds a short documentation about the new file naming strategy, based on @jamiebuilds table in https://github.com/parcel-bundler/parcel/pull/1025

Related #132