### PR TITLE
Fix hmr.md links

### DIFF
--- a/src/i18n/en/docs/hmr.md
+++ b/src/i18n/en/docs/hmr.md
@@ -22,9 +22,9 @@ if (module.hot) {
 
 Whenever Parcel comes across a dependency that fits the `node_module` pattern and can't find it, Parcel tries to install this dependency using `yarn` or `npm` depending on finding a `yarn.lock` file or not. This prevents the developer from having to exit parcel or having multiple terminal windows open.
 
-This only occurs in *development* (using [`serve`](./cli.html#serve) or [`watch`](./cli.html#watch)), in production (using [`build`](./cli.html#serve)) autoinstall is disabled to prevent unwanted side-effects on deployment.
+This only occurs in *development* (using [`serve`](cli.md#serve) or [`watch`](cli.md#watch)), however in production (using [`build`](cli.md#build)) autoinstall is disabled to prevent unwanted side-effects on deployment.
 
-You can disable this feature using [`--no-autoinstall`](./cli.html#disable-autoinstall).
+You can disable this feature using [`--no-autoinstall`](cli.md#disable-autoinstall).
 
 ## Safe Write
 Some text editors and IDE's have a feature called `safe write` this basically prevents data loss, by taking a copy of the file and renaming it when saved.


### PR DESCRIPTION
In general, it would be necessary to remove .\*.html and replace by *.md for the 4 added links

