### PR TITLE
Highlight links in <code>

### DIFF
--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -180,6 +180,10 @@ p code {
   display: inline-block;
 }
 
+p a code{
+  color: #0645ad; text-decoration:none;
+}
+
 b, strong { font-weight: bold; }
 
 dfn { font-style: italic; }


### PR DESCRIPTION
## Description

The links in the `<code>` tag are not visually highlighted. This PR does the necessary to improve this.

## Before

![before](https://user-images.githubusercontent.com/163352/42492407-47524cb0-8419-11e8-9b8b-b6eacb14ba69.PNG)

## After

![after](https://user-images.githubusercontent.com/163352/42492420-526cb162-8419-11e8-8074-c241c5cf2fd8.PNG)

