### PR TITLE
Add export to asset types example

### DIFF
--- a/src/i18n/en/docs/asset_types.md
+++ b/src/i18n/en/docs/asset_types.md
@@ -51,6 +51,8 @@ class MyAsset extends Asset {
     // Can be used for combining multiple asset types
   }
 }
+
+module.exports = MyAsset
 ```
 
 ## Registering an Asset Type

--- a/src/i18n/en/docs/packagers.md
+++ b/src/i18n/en/docs/packagers.md
@@ -23,6 +23,8 @@ class MyPackager extends Packager {
     await this.dest.end(trailer);
   }
 }
+
+module.exports = MyPackager
 ```
 
 ## Registering a Packager


### PR DESCRIPTION
This might sound silly, but I got stuck for over an hour trying to figure out what was going on with the exports. From the example, I assumed the worker process automagically extracted the class with some other mechanism.