### PR TITLE
Update translation in french

### DIFF
--- a/src/i18n/fr/docs/api.md
+++ b/src/i18n/fr/docs/api.md
@@ -8,8 +8,12 @@ Un exemple de watch avec chaque option expliquée :
 const Bundler = require('parcel-bundler');
 const Path = require('path');
 
-// Emplacement du fichier d'entrée
-const file = Path.join(__dirname, './index.html');
+// Emplacement du fichier unique en point d'entrée :
+const entryFiles = Path.join(__dirname, './index.html');
+// OU : Plusieurs fichiers avec un glob (cela peut être aussi un .js)
+// const entryFiles = './src/*.js';
+// OU : Plusieurs fichiers dans un tableau
+// const entryFiles = ['./src/index.html', './un/autre/repertoire/scripts.js'];
 
 // Options de l'empaqueteur
 const options = {
@@ -23,7 +27,10 @@ const options = {
   minify: false, // Minifie les fichiers, activé par défaut si process.env.NODE_ENV === 'production'
   scopeHoist: false, // Active le flag expérimental de scope hoisting/tree shaking, pour des paquets plus petits en production
   target: 'browser', // la cible de compilation : browser/node/electron, par défaut browser
-  https: false, // Sert les fichiers sur https ou http, par défaut à false
+  https: { // Définit une paire personnalisée {key, cert}, utilisez true pour en générer un ou false pour utiliser http
+    cert: './ssl/c.crt', // chemin vers le certificat personnalisé
+    key: './ssl/k.key' // chemin vers la clé personnalisée
+  },
   logLevel: 3, // 3 = Tout consigner, 2 = Consigner les erreurs et les avertissements, 1 = Consigner uniquement les erreurs
   hmrPort: 0, // Le port sur lequel la socket HMR (Hot Module Reload) fonctionne, par défaut à un port libre aléatoire (0 dans node.js se traduit en un port libre aléatoire)
   sourceMaps: true, // Active ou désactive les sourcemaps, par défaut activé (pas encore pris en charge dans les versions minifiées)
@@ -33,7 +40,7 @@ const options = {
 
 async function runBundle() {
   // Initialise un empaqueteur (bundler) en utilisant l'emplacement de l'entrée et les options fournies
-  const bundler = new Bundler(file, options);
+  const bundler = new Bundler(entryFiles, options);
 
   // Démarre l'empaqueteur, cela renvoie le paquet principal
   // Utilisez les événements si vous êtes en mode watch, car cette Promise n'est résolue qu'une seule fois et non à chaque reconstruction

--- a/src/i18n/fr/docs/getting_started.md
+++ b/src/i18n/fr/docs/getting_started.md
@@ -54,4 +54,30 @@ Utilisez le serveur de développement lorsque vous n'avez pas votre propre serve
 parcel watch index.html
 ```
 
+### Plusieurs fichiers comme point d'entrée
+
+Si vous avez plusieurs fichiers comme point d'entrée, disons `index.html` et `about.html`, vous avez deux façons d'exécuter l'empaqueteur :
+
+En spécifiant les noms des fichiers :
+```bash
+parcel index.html about.html
+```
+
+Utilisez des tokens et créez un glob :
+```bash
+parcel *.html
+```
+
+*REMARQUE :* Si vous avez une structure de fichier comme celle-ci :
+```
+- répertoire-1
+-- index.html
+- répertoire-2
+-- index.html
+```
+
+La recherche vers http://localhost:1234/folder-1/ ne fonctionnera pas, à la place, vous devez indiquer explicitement le fichier http://localhost:1234/folder-1/index.html.
+
+### Construction pour la production
+
 Lorsque vous êtes prêt à construire les fichiers finals utilisés pour la production, le mode `build` arrête de scruter les modifications et ne construit qu'une seule fois. Consultez la section [Production](production.html) pour plus de détails.

--- a/src/i18n/fr/index.html
+++ b/src/i18n/fr/index.html
@@ -48,8 +48,8 @@
           <option class="zh" value="https://zh.parceljs.org">中文</option>
         </select>
       </form>
-      <a href="getting_started.html">Documentation</a>
       <a href="https://github.com/parcel-bundler/parcel" target="_blank">GitHub</a>
+      <a href="getting_started.html">Documentation</a>
     </nav>
   </header>
 


### PR DESCRIPTION
1. Add multiple entry files description (parcel-bundler/website@2384ca6559f53635f8a819207f164d9d0f750365)
2. Documentation for custom ssl certificate and key in API (parcel-bundler/website@89da9c6ee824d1aae29bb67a2f6aecda2c45c830)
3. API Docs for multiple entry files (parcel-bundler/website@ff6c97b97bf199a6b9ca67f4e12a44258042d995)
4. Swap buttons (parcel-bundler/website@cad77e215d7131a72be128175426105bd9ca7bab)