### PR TITLE
Inform of scoped plugin name support

### DIFF
--- a/src/i18n/en/docs/plugins.md
+++ b/src/i18n/en/docs/plugins.md
@@ -19,4 +19,4 @@ Publish this package on npm using `parcel-plugin-` or `@your-scope/parcel-plugin
 
 ## Using Plugins
 
-Using plugins in Parcel could not be any simpler. All you need to do is install them and save in your `package.json`. Plugins should be named with the prefix `parcel-plugin-` or `@your-scope/parcel-plugin-`, e.g. `parcel-plugin-foo` or `@your-scope/parcel-plugin-foo`. Any dependencies listed in `package.json` with these prefixes will be automatically loaded during initialization.
+Using plugins in Parcel could not be any simpler. All you need to do is install and save them in your `package.json`. Plugins should be named with the prefix `parcel-plugin-` or `@your-scope/parcel-plugin-`, e.g. `parcel-plugin-foo` or `@your-scope/parcel-plugin-foo`. Any dependencies listed in `package.json` with these prefixes will automatically be loaded during initialization.

--- a/src/i18n/en/docs/plugins.md
+++ b/src/i18n/en/docs/plugins.md
@@ -15,8 +15,8 @@ module.exports = function (bundler) {
 };
 ```
 
-Publish this package on npm using the `parcel-plugin-` prefix, and it will be automatically detected and loaded as described below.
+Publish this package on npm using `parcel-plugin-` or `@your-scope/parcel-plugin-` prefixes, and it will be automatically detected and loaded as described below.
 
 ## Using Plugins
 
-Using plugins in Parcel could not be any simpler. All you need to do is install them and save in your `package.json`. Plugins should be named with the prefix `parcel-plugin-`, e.g. `parcel-plugin-foo`. Any dependencies listed in `package.json` with this prefix will be automatically loaded during initialization.
+Using plugins in Parcel could not be any simpler. All you need to do is install them and save in your `package.json`. Plugins should be named with the prefix `parcel-plugin-` or `@your-scope/parcel-plugin-`, e.g. `parcel-plugin-foo` or `@your-scope/parcel-plugin-foo`. Any dependencies listed in `package.json` with these prefixes will be automatically loaded during initialization.


### PR DESCRIPTION
Scoped plugin names `@your-scope/parcel-plugin` is supported but not mentioned in the docs, let's do that.