### PR TITLE
document env file support

### DIFF
--- a/src/i18n/en/docs/env.md
+++ b/src/i18n/en/docs/env.md
@@ -1,0 +1,19 @@
+# 🌳 Environment Variables
+
+Parcel uses [dotenv](https://github.com/motdotla/dotenv) to support loading environment variables from `.env` files.
+
+`.env` files are to be stored alongside the `package.json` that contains your `parcel-bundler` dependency.
+
+Parcel loads `.env` files with following names:
+
+| valid `.env` filenames   | `NODE_ENV=\*` | `NODE_ENV=test` |
+| ------------------------ | ------------- | --------------- |
+| `.env`                   | ✔️            | ✔️              |
+| `.env.local`             | ✔️            | ✖️              |
+| `.env.${NODE_ENV}`       | ✔️            | ✔️              |
+| `.env.${NODE_ENV}.local` | ✔️            | ✔️              |
+
+Notably:
+
+- `NODE_ENV` defaults to `development`.
+- `.env.local` is not loaded when `NODE_ENV=test` since [tests should produce the same results for everyone](https://github.com/parcel-bundler/parcel/blob/28df546a2249b6aac1e529dd629f506ba6b0a4bb/src/utils/env.js#L9)

--- a/src/i18n/en/docs/env.md
+++ b/src/i18n/en/docs/env.md
@@ -4,7 +4,7 @@ Parcel uses [dotenv](https://github.com/motdotla/dotenv) to support loading envi
 
 `.env` files are to be stored alongside the `package.json` that contains your `parcel-bundler` dependency.
 
-Parcel loads `.env` files with following names:
+Parcel loads `.env` files with these specific names for the following `NODE_ENV` values:
 
 | valid `.env` filenames   | `NODE_ENV=\*` | `NODE_ENV=test` |
 | ------------------------ | ------------- | --------------- |

--- a/src/i18n/en/layout/page.html
+++ b/src/i18n/en/layout/page.html
@@ -47,6 +47,7 @@
         <li><a href="assets.html">📦 Assets</a></li>
         <li><a href="transforms.html">🐠 Transforms</a></li>
         <li><a href="code_splitting.html">✂️ Code Splitting</a></li>
+        <li><a href="env.html">🌳 Environment Variables</a></li>
         <li><a href="hmr.html">🔥 Hot Module Replacement</a></li>
         <li><a href="production.html">✨ Production</a></li>
         <li><a href="recipes.html">🍰 Recipes</a></li>


### PR DESCRIPTION
This is my suggestion for documenting `.env` support https://github.com/parcel-bundler/parcel/pull/258.

The original suggestion https://github.com/parcel-bundler/website/issues/216 was for this to be listed under the
>advanced section

but most of the advanced section is about authoring plugins/packagers and using the direct api. I thought keeping it alongside the usage explanation, namely post Code Splitting, a better fit.

I may raise an issue in the future to discuss reorganising the documentation as I've found it difficult for a number of reasons in the past.