### PR TITLE
Update translation in french

### DIFF
--- a/src/i18n/fr/docs/api.md
+++ b/src/i18n/fr/docs/api.md
@@ -32,6 +32,7 @@ const options = {
     key: './ssl/k.key' // chemin vers la clé personnalisée
   },
   logLevel: 3, // 3 = Tout consigner, 2 = Consigner les erreurs et les avertissements, 1 = Consigner uniquement les erreurs
+  hmr: true, // Active ou désactive le HMR lors de la surveillance (watch)
   hmrPort: 0, // Le port sur lequel la socket HMR (Hot Module Reload) fonctionne, par défaut à un port libre aléatoire (0 dans node.js se traduit en un port libre aléatoire)
   sourceMaps: true, // Active ou désactive les sourcemaps, par défaut activé (pas encore pris en charge dans les versions minifiées)
   hmrHostname: '', // Un nom d'hôte pour le rechargement de module à chaud, par défaut à ''

--- a/src/i18n/fr/docs/assets.md
+++ b/src/i18n/fr/docs/assets.md
@@ -86,3 +86,36 @@ Une ressource HTML est souvent le fichier d'entrée que vous fournissez à Parce
 </body>
 </html>
 ```
+
+## Ressources prises en charge par défaut
+
+| Type de ressources             | Extension(s) associée(s)         |
+| ------------------------------ | -------------------------------- |
+| JavaScript                     | `js`, `jsx`, `es6`, `jsm`, `mjs` |
+| ReasonML                       | `ml`,`re`                        |
+| TypeScript                     | `ts`, `tsx`                      |
+| CoffeeScript                   | `coffee`                         |
+| Vue                            | `vue`                            |
+| JSON                           | `json`, `json5`                  |
+| YAML                           | `yaml`, `yml`                    |
+| TOML                           | `toml`                           |
+| GraphQL                        | `gql`, `graphql`                 |
+| CSS                            | `css`, `pcss`, `postcss`         |
+| Stylus                         | `stylus`                         |
+| LESS                           | `less`                           |
+| SASS                           | `sass`, `scss`                   |
+| HTML                           | `htm`, `html`                    |
+| Rust                           | `rs`                             |
+| WebManifest                    | `webmanifest`                    |
+| OpenGL Shading Language (GLSL) | `glsl`, `vert`, `frag`           |
+| Pug                            | `jade`, `pug`                    |
+
+<sub>\* Pour les types de ressources actuellement pris en charge, la documentation peut devenir obsolète, consultez [parcel/src/Parser.js](https://github.com/parcel-bundler/parcel/blob/28df546a2249b6aac1e529dd629f506ba6b0a4bb/src/Parser.js#L10). Pour la liste actuelle des parsers, consultez [parcel/src/assets/](https://github.com/parcel-bundler/parcel/tree/master/src/assets).</sub>
+
+Pour tout type de ressources non pris en charge par défaut, vous pouvez vérifier si un plugin existe déjà :
+
+- [Yarn](https://yarnpkg.com/en/packages?q=parcel-plugin-&p=1)
+- [npm](https://www.npmjs.com/search?q=parcel-plugin-)
+- [awesome-parcel](https://github.com/parcel-bundler/awesome-parcel#plugins)
+
+ou [créez le votre](https://parceljs.org/plugins.html).

--- a/src/i18n/fr/docs/env.md
+++ b/src/i18n/fr/docs/env.md
@@ -1,0 +1,19 @@
+# 🌳 Variables d'environnement
+
+Parcel utilise [dotenv](https://github.com/motdotla/dotenv) pour charger les variables d'environnement depuis les fichiers `.env`.
+
+Les fichiers `.env` doivent être placés au même endroit que le `package.json` qui contient votre dépendance `parcel-bundler`.
+
+Parcel charge les fichiers `.env` avec ces noms spécifiques pour les valeurs de `NODE_ENV` suivantes :
+
+| Nom de fichier `.env` valide | `NODE_ENV=\*` | `NODE_ENV=test` |
+| ---------------------------- | ------------- | --------------- |
+| `.env`                       | ✔️            | ✔️              |
+| `.env.local`                 | ✔️            | ✖️              |
+| `.env.${NODE_ENV}`           | ✔️            | ✔️              |
+| `.env.${NODE_ENV}.local`     | ✔️            | ✔️              |
+
+Notamment :
+
+- `NODE_ENV` est par défaut à `development`.
+- `.env.local` n'est pas chargé quand `NODE_ENV=test` car [les tests doivent produire les mêmes résultats pour tout le monde](https://github.com/parcel-bundler/parcel/blob/28df546a2249b6aac1e529dd629f506ba6b0a4bb/src/utils/env.js#L9)

--- a/src/i18n/fr/docs/module_resolution.md
+++ b/src/i18n/fr/docs/module_resolution.md
@@ -1,0 +1,98 @@
+# 📔 Résolution de module
+
+Parcel (v1.7.0 et versions ultérieures) prend en charge plusieurs stratégies de résolution de module prêtes à l'emploi, ce qui vous évite de devoir gérer des chemins relatifs sans fin, par exemple `../../`.
+
+Termes notable :
+
+- **racine du projet** : le répertoire du point d'entrée spécifié à Parcel ou la racine partagée (répertoire parent commun) lorsque plusieurs points d'entrée sont spécifiés.
+- **racine du package** : le répertoire racine du module le plus proche dans `node_modules`.
+
+## Chemins absolus
+
+`/foo` résoudra `foo` relatif à la **racine du projet**.
+
+## Chemins du tilde ~
+
+`~/foo` résoudra `foo` relatif à la **racine du package** le plus proche ou, s'il ne trouve pas, à la **racine du projet**.
+
+## Alias
+
+Les alias sont supportés via le champ `alias` dans `package.json`.
+
+Ces exemples d'alias `react` vers `preact` et d'un module local personnalisé qui ne sont pas dans `node_modules`.
+
+```json
+// package.json
+{
+  "name": "some-package",
+  "devDependencies": {
+    "parcel-bundler": "^1.7.0"
+  },
+  "alias": {
+    "react": "preact-compat",
+    "react-dom": "preact-compat",
+    "local-module": "./custom/modules"
+  }
+}
+```
+
+Évitez d'utiliser des caractères spéciaux dans vos alias, car certains peuvent être utilisés par Parcel et d'autres par des outils ou des extensions tiers. Par exemple :
+
+- `~` utilisé par Parcel pour résoudre les [chemins du tilde](#chemins-du-tilde-~).
+- `@` utilisé par npm pour résoudre les organisations de npm.
+
+Nous vous conseillons d'être explicite lors de la définition de vos alias, veuillez donc **spécifier les extensions de fichier**, sinon Parcel devra le deviner. Consultez [Export nommés de JavaScript](#export-nommés-de-javascript) pour voir un exemple.
+
+## Autres conditions
+
+### Export nommés de JavaScript
+
+Les cartographies d'alias s'appliquent à de nombreux types d'actifs, mais ne prennent pas spécifiquement en charge la cartographie des exports nommées de JavaScript. Si vous souhaitez cartographier les exports nommées JS, vous pouvez le faire ainsi :
+
+```json
+// package.json
+{
+  "name": "some-package",
+  "alias": {
+    "ipcRenderer": "./electron-ipc.js" // specifiez une extension de fichier
+  }
+}
+```
+
+et réexporter l'export nommé dans le fichier aliasé :
+
+```js
+// electron-ipc.js
+module.exports = require("electron").ipcRenderer;
+```
+
+### Résolution TypeScript ~
+
+TypeScript devra connaître votre utilisation de la résolution de module `~` ou les cartographies d'alias. Veuillez vous reporter à la documentation de [TypeScript Module Resolution docs](https://www.typescriptlang.org/docs/handbook/module-resolution.html) pour plus d'informations.
+
+```json
+// tsconfig.json
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "~*": ["./src/*"]
+    }
+  }
+}
+```
+
+### Résolution Monorepo
+
+Ce sont  en ce moment les utilisations conseillées avec des monorepos :
+
+Utilisation conseillée :
+
+- utilisez les chemins relatifs.
+- utilisez `/` pour un chemin racine si une racine est requise.
+
+Utilisation déconseillée :
+
+- **évitez** l'utilisation de `~` dans les monorepos.
+
+Si vous êtes un utilisateur de monorepo et que vous souhaitez contribuer à ces recommandations, veuillez fournir des exemples de repos lors de l'ouverture d'issue pour aider la discussion.

--- a/src/i18n/fr/docs/plugins.md
+++ b/src/i18n/fr/docs/plugins.md
@@ -15,8 +15,8 @@ module.exports = function (bundler) {
 };
 ```
 
-Publiez ce paquet sur npm en utilisant le préfixe `parcel-plugin-` et il sera automatiquement détecté et chargé comme décrit ci-dessous.
+Publiez ce paquet sur npm en utilisant les préfixes `parcel-plugin-` ou `@votre-scope/parcel-plugin-` et il sera automatiquement détecté et chargé comme décrit ci-dessous.
 
 ## Utilisations des Plugins
 
-L'utilisation de plugins dans Parcel ne pouvait pas être plus simple. Tout ce que vous avez à faire est de les installer et de les enregistrer dans votre `package.json`. Les plugins doivent être nommés avec le préfixe `parcel-plugin-`, par exemple `parcel-plugin-foo`. Toutes les dépendances répertoriées dans `package.json` avec ce préfixe seront automatiquement chargés lors de l'initialisation.
+L'utilisation de plugins dans Parcel ne pouvait pas être plus simple. Tout ce que vous avez à faire est de les installer et de les enregistrer dans votre `package.json`. Les plugins doivent être nommés avec les préfixes `parcel-plugin-` ou `@votre-scope/parcel-plugin-`, par exemple `parcel-plugin-foo` ou `@votre-scope/parcel-plugin-foo`. Toutes les dépendances répertoriées dans `package.json` avec ces préfixes seront automatiquement chargés lors de l'initialisation.

--- a/src/i18n/fr/layout/page.html
+++ b/src/i18n/fr/layout/page.html
@@ -45,8 +45,10 @@
       <ul>
         <li><a href="getting_started.html">🚀 Commencer</a></li>
         <li><a href="assets.html">📦 Ressources</a></li>
+        <li><a href="module_resolution.html">📔 Résolution de module</a></li>
         <li><a href="transforms.html">🐠 Transformations</a></li>
         <li><a href="code_splitting.html">✂️ Découpage du code</a></li>
+        <li><a href="env.html">🌳 Variables d'environnement</a></li>
         <li><a href="hmr.html">🔥 Remplacement de module à chaud</a></li>
         <li><a href="production.html">✨ Production</a></li>
         <li><a href="recipes.html">🍰 Recettes</a></li>


### PR DESCRIPTION
1. Inform of scoped plugin name support (parcel-bundler/website@4bf63950211e2917552237a44d45fc1e3aa71b1d)
2. Document default supported assets (parcel-bundler/website@3dc68badf6f2436e89ae200fea26999a3d86b97c)
3. Document env file support (parcel-bundler/website@ead9587d5bae0fe82677781fcaa519ca91765abe)
4. Added missing `hmr` option to API documentation (parcel-bundler/website@7b7d8c7c611b06e837210fef2639069bfe6c8881)
5. Document module resolution strategies (parcel-bundler/website@ea55206a9cee4dee48052745e741cb7f323e365e)