### PR TITLE
Update babel notes to use scoped package names

### DIFF
--- a/src/i18n/en/docs/transforms.md
+++ b/src/i18n/en/docs/transforms.md
@@ -11,7 +11,7 @@ This even works in third-party `node_modules`: if a configuration file is publis
 Install presets and plugins in your app:
 
 ```bash
-yarn add babel-preset-react
+yarn add @babel/preset-react
 ```
 
 Then, create a `.babelrc`:
@@ -19,14 +19,14 @@ Then, create a `.babelrc`:
 ```json
 {
   "presets": [
-    "react"
+    "@babel/preset-react"
   ]
 }
 ```
 
 ### Default babel transforms
 
-Parcel transpiles your code with `babel-preset-env` by default, this is to transpile every module both internal (local requires) and external (node_modules) to match the defined target.
+Parcel transpiles your code with `@babel/preset-env` by default, this is to transpile every module both internal (local requires) and external (node_modules) to match the defined target.
 
 For the `browser` target it utilises [browserlist](https://github.com/browserslist/browserslist), the target browserlist can be defined in `package.json` (`engines.browsers` or `browserslist`) or using a configuration file (`browserslist` or `.browserslistrc`).
 

--- a/src/i18n/es/docs/transforms.md
+++ b/src/i18n/es/docs/transforms.md
@@ -11,14 +11,14 @@ Esto funciona incluso en módulos de terceros dentro de la carpeta `node_modules
 Instala los presets y plugins en tu app:
 
 ```bash
-yarn add babel-preset-env
+yarn add @babel/preset-env
 ```
 
 Luego, crea un archivo `.babelrc`:
 
 ```json
 {
-  "presets": ["env"]
+  "presets": ["@babel/preset-env"]
 }
 ```
 

--- a/src/i18n/fr/docs/transforms.md
+++ b/src/i18n/fr/docs/transforms.md
@@ -11,7 +11,7 @@ Cela fonctionne même dans des `node_modules` tiers : si un fichier de configura
 Installez les presets et les plugins dans votre application :
 
 ```bash
-yarn add babel-preset-react
+yarn add @babel/preset-react
 ```
 
 Ensuite, créez un `.babelrc`:
@@ -19,14 +19,14 @@ Ensuite, créez un `.babelrc`:
 ```json
 {
   "presets": [
-    "react"
+    "@babel/preset-react"
   ]
 }
 ```
 
 ### Transformations babel par défaut
 
-Parcel transpile par défaut votre code avec `babel-preset-env`, ceci transpile chaque module interne (requires locaux) et externe (node_modules) pour correspondre à la cible définie.
+Parcel transpile par défaut votre code avec `@babel/preset-env`, ceci transpile chaque module interne (requires locaux) et externe (node_modules) pour correspondre à la cible définie.
 
 Pour la cible `browser`, il utilise [browserlist](https://github.com/browserslist/browserslist), la browserlist cible peut être définie dans le fichier `package.json` (`engines.browsers` ou `browserslist`) ou en utilisant un fichier de configuration (`browserslist` ou `.browserslistrc`).
 

--- a/src/i18n/it/docs/transforms.md
+++ b/src/i18n/it/docs/transforms.md
@@ -11,14 +11,14 @@ Questo processo funziona anche in `node_modules` di terze parti: se un file di c
 Installa i preset e i plugins nella tua app:
 
 ```bash
-yarn add babel-preset-env
+yarn add @babel/preset-env
 ```
 
 Poi, crea un file `.babelrc`:
 
 ```json
 {
-  "presets": ["env"]
+  "presets": ["@babel/preset-env"]
 }
 ```
 

--- a/src/i18n/ko/docs/transforms.md
+++ b/src/i18n/ko/docs/transforms.md
@@ -11,14 +11,14 @@
 플러그인과 프리셋을 앱에 설치 하세요:
 
 ```bash
-yarn add babel-preset-env
+yarn add @babel/preset-env
 ```
 
 그리고나서, `.babelrc`를 만듭니다:
 
 ```json
 {
-  "presets": ["env"]
+  "presets": ["@babel/preset-env"]
 }
 ```
 

--- a/src/i18n/pl/docs/transforms.md
+++ b/src/i18n/pl/docs/transforms.md
@@ -11,14 +11,14 @@ To zachowanie działa nawet w `node_modules`: jeśli plik konfiguracyjny jest op
 Zainstaluj presety i wtyczki w aplikacji wykonując:
 
 ```bash
-yarn add babel-preset-env
+yarn add @babel/preset-env
 ```
 
 Następnie utwórz plik `.babelrc`:
 
 ```json
 {
-  "presets": ["env"]
+  "presets": ["@babel/preset-env"]
 }
 ```
 

--- a/src/i18n/pt/docs/transforms.md
+++ b/src/i18n/pt/docs/transforms.md
@@ -11,14 +11,14 @@ Isso funciona mesmo em módulos externos (`node_modules`): se um arquivo de conf
 Instale as predefinições e plugins na sua aplicação:
 
 ```bash
-yarn add babel-preset-env
+yarn add @babel/preset-env
 ```
 
 Crie o arquivo `.babelrc`:
 
 ```json
 {
-  "presets": ["env"]
+  "presets": ["@babel/preset-env"]
 }
 ```
 

--- a/src/i18n/ru/docs/transforms.md
+++ b/src/i18n/ru/docs/transforms.md
@@ -11,16 +11,20 @@
 Установка пресетов и плагинов в приложении:
 
 ```bash
-yarn add babel-preset-env
+yarn add @babel/preset-react
 ```
 
 Затем создайте `.babelrc`:
 
 ```json
 {
-  "presets": ["env"]
+  "presets": ["@babel/preset-react"]
 }
 ```
+
+### Транспиляция babel'ем по умолчанию
+
+Parcel транспилирует ваш код с пресетом `@babel/preset-env` по умолчанию, с его помощью каждый внутренний (локальные require'ы) и внешние (node_modules) будут транспилировны под указанный target.
 
 ## PostCSS
 

--- a/src/i18n/zh/docs/transforms.md
+++ b/src/i18n/zh/docs/transforms.md
@@ -11,14 +11,14 @@
 在你的应用程序中安装 presets 和 plugins :
 
 ```bash
-yarn add babel-preset-env
+yarn add @babel/preset-env
 ```
 
 接着，创建一个 `.babelrc`:
 
 ```json
 {
-  "presets": ["env"]
+  "presets": ["@babel/preset-env"]
 }
 ```
 


### PR DESCRIPTION
I saw that the parcel itself has been [updated](https://github.com/parcel-bundler/parcel/blob/master/package.json#L18-L29) to use the most recent babel version with scoped packages so I have attempted to mirror it in the docs as well.

The languages I don't speak I changed the preset names and for Russian doc I've updated the documentation to match the english version