### PR TITLE
Added infos about cli's "--target" flag regarding package bundling

### DIFF
--- a/src/i18n/en/docs/cli.md
+++ b/src/i18n/en/docs/cli.md
@@ -91,7 +91,7 @@ Available in: `serve`, `watch`, `build`
 parcel build entry.js --target node
 ```
 
-⚠️ Target `node` and `electron` will not bundle package.json's `dependencies` (but will include `devDependencies`).
+⚠️ Target `node` and `electron` will not bundle package.json's `dependencies` (but will include `devDependencies`). This behavior can be overriden using --bundle-node-modules flag (see below)
 
 Possible targets: `node`, `browser`, `electron`
 

--- a/src/i18n/en/docs/cli.md
+++ b/src/i18n/en/docs/cli.md
@@ -91,7 +91,7 @@ Available in: `serve`, `watch`, `build`
 parcel build entry.js --target node
 ```
 
-⚠️ Target `node` and `electron` will not bundle package.json's `dependencies` (but will include `devDependencies`). This behavior can be overriden using --bundle-node-modules flag (see below)
+⚠️ Target `node` and `electron` will not bundle package.json's `dependencies` (but will include `devDependencies`). This behavior can be overriden using [--bundle-node-modules](#force-node-modules-bundling) flag (see below).
 
 Possible targets: `node`, `browser`, `electron`
 

--- a/src/i18n/en/docs/cli.md
+++ b/src/i18n/en/docs/cli.md
@@ -91,9 +91,21 @@ Available in: `serve`, `watch`, `build`
 parcel build entry.js --target node
 ```
 
-⚠️ Target `node` and `electron` will not bundle package.json's `dependencies` (but will include `devDependencies`)
+⚠️ Target `node` and `electron` will not bundle package.json's `dependencies` (but will include `devDependencies`).
 
 Possible targets: `node`, `browser`, `electron`
+
+### Force node modules bundling
+
+Default: false
+
+Available in: `serve`, `watch`, `build`
+
+```bash
+parcel build entry.js --target node --bundle-node-modules
+```
+
+By default, package.json's `dependencies` are not included when using `--target node` or `--target electron`. This flag adds them to the bundle.
 
 ### Cache directory
 

--- a/src/i18n/en/docs/cli.md
+++ b/src/i18n/en/docs/cli.md
@@ -91,6 +91,8 @@ Available in: `serve`, `watch`, `build`
 parcel build entry.js --target node
 ```
 
+⚠️ Target `node` and `electron` will not bundle package.json's `dependencies` (but will include `devDependencies`)
+
 Possible targets: `node`, `browser`, `electron`
 
 ### Cache directory


### PR DESCRIPTION
Allows for a more concious choice of export.

I use parcel to bundle npm libraries, discovering "dependencies" are not bundled in "node" export mode was of great use :)