### PR TITLE
Sync 'recipes' documentation for pt lang

### DIFF
--- a/src/i18n/en/docs/recipes.md
+++ b/src/i18n/en/docs/recipes.md
@@ -94,7 +94,6 @@ Add Start script to `package.json`
 }
 ```
 
-
 ## Typescript
 
 First we need to add Parcel and Typescript to our project.
@@ -103,7 +102,9 @@ First we need to add Parcel and Typescript to our project.
 npm install --save-dev typescript
 npm install --save-dev parcel-bundler
 ```
+
 <sub>Or if you have the optional Yarn package manager installed</sub>
+
 ```bash
 yarn add typescript --dev
 yarn add --dev parcel-bundler
@@ -140,6 +141,7 @@ Done!
 ### Compiling the `.ts` file directly
 
 Add Start script to `package.json`
+
 ```javascript
 // package.json
 "scripts": {

--- a/src/i18n/pt/docs/recipes.md
+++ b/src/i18n/pt/docs/recipes.md
@@ -12,7 +12,7 @@ npm install --save react-dom
 npm install --save-dev parcel-bundler
 ```
 
-<sub>Ou se você tiver opcionalmente do gerenciador de pacotes Yarn instalado</sub>
+<sub>Ou se você tiver opcionalmente o gerenciador de pacotes Yarn instalado</sub>
 
 ```bash
 yarn add react
@@ -40,7 +40,7 @@ npm install --save-dev parcel-bundler
 npm install --save-dev babel-preset-preact
 ```
 
-<sub>Ou se você tiver opcionalmente do gerenciador de pacotes Yarn instalado</sub>
+<sub>Ou se você tiver opcionalmente o gerenciador de pacotes Yarn instalado</sub>
 
 ```bash
 yarn add preact
@@ -78,7 +78,7 @@ npm install --save vue
 npm install --save-dev parcel-bundler
 ```
 
-<sub>Ou se você tiver opcionalmente do gerenciador de pacotes Yarn instalado</sub>
+<sub>Ou se você tiver opcionalmente o gerenciador de pacotes Yarn instalado</sub>
 
 ```bash
 yarn add vue
@@ -103,7 +103,7 @@ npm install --save-dev typescript
 npm install --save-dev parcel-bundler
 ```
 
-<sub>Ou se você tiver opcionalmente do gerenciador de pacotes Yarn instalado</sub>
+<sub>Ou se você tiver opcionalmente o gerenciador de pacotes Yarn instalado</sub>
 
 ```bash
 yarn add typescript --dev

--- a/src/i18n/pt/docs/recipes.md
+++ b/src/i18n/pt/docs/recipes.md
@@ -10,30 +10,17 @@ Primeiro instale as dependências do React.
 npm install --save react
 npm install --save react-dom
 npm install --save-dev parcel-bundler
-npm install --save-dev babel-preset-env
-npm install --save-dev babel-preset-react
 ```
 
-<sub>Caso você tenha o Yarn instalado</sub>
+<sub>Ou se você tiver opcionalmente do gerenciador de pacotes Yarn instalado</sub>
 
 ```bash
 yarn add react
 yarn add react-dom
 yarn add --dev parcel-bundler
-yarn add --dev babel-preset-env
-yarn add --dev babel-preset-react
 ```
 
-Em seguida, verifique se a configuração do Babel está presente.
-
-```javascript
- // .babelrc
-{
-  "presets": ["env", "react"]
-}
-```
-
-Adicione o script Start no `package.json`
+Adicione o script de inicialização ao `package.json`
 
 ```javascript
 // package.json
@@ -50,30 +37,30 @@ Primeiro instale as dependências do Preact.
 npm install --save preact
 npm install --save preact-compat
 npm install --save-dev parcel-bundler
-npm install --save-dev babel-preset-env
 npm install --save-dev babel-preset-preact
 ```
 
-<sub>Caso você tenha o Yarn instalado</sub>
+<sub>Ou se você tiver opcionalmente do gerenciador de pacotes Yarn instalado</sub>
 
 ```bash
 yarn add preact
 yarn add preact-compat
 yarn add --dev parcel-bundler
-yarn add --dev babel-preset-env
 yarn add --dev babel-preset-preact
 ```
 
-Em seguida, verifique se a configuração do Babel está presente.
+Então verifique se a seguinte configuração do Babel está presente.
 
 ```javascript
 // .babelrc
 {
-  "presets": ["env", "preact"]
+  "presets": [
+    "preact"
+  ]
 }
 ```
 
-Adicione o script Start no `package.json`
+Adicione o script de inicialização ao `package.json`
 
 ```javascript
 // package.json
@@ -81,3 +68,85 @@ Adicione o script Start no `package.json`
   "start": "parcel index.html"
 }
 ```
+
+## Vue
+
+Primeiro, nós precisamos instalar as dependências para o Vue.
+
+```bash
+npm install --save vue
+npm install --save-dev parcel-bundler
+```
+
+<sub>Ou se você tiver opcionalmente do gerenciador de pacotes Yarn instalado</sub>
+
+```bash
+yarn add vue
+yarn add --dev parcel-bundler
+```
+
+Adicione o script de inicialização ao `package.json`
+
+```javascript
+// package.json
+"scripts": {
+  "start": "parcel index.html"
+}
+```
+
+## Typescript
+
+Primeiro, nós temos que adicionar o Parcel e Typescript ao nosso projeto.
+
+```bash
+npm install --save-dev typescript
+npm install --save-dev parcel-bundler
+```
+
+<sub>Ou se você tiver opcionalmente do gerenciador de pacotes Yarn instalado</sub>
+
+```bash
+yarn add typescript --dev
+yarn add --dev parcel-bundler
+```
+
+### Compilando a partir do index.html
+
+Adicione o script de inicialização ao `package.json`
+
+```javascript
+// package.json
+"scripts": {
+  "start": "parcel index.html"
+}
+```
+
+E então, no seu arquivo `index.html`, simplesmente referencie o seu arquivo `.ts`.
+
+```html
+<!-- index.html -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+</head>
+<body>
+    <!-- Aqui 👇 -->
+    <script src="./myTypescriptFile.ts"></script>
+</body>
+</html>
+```
+
+Feito!
+
+### Compilando o arquivo `.ts` diretamente 
+
+Adicione o script de inicialização ao `package.json`
+
+```javascript
+// package.json
+"scripts": {
+  "start": "parcel myTypescriptFile.ts"
+}
+```
+
+Feito! 😄 O arquivo `.js` compilado pode ser encontrado dentro do diretório de distribuição.


### PR DESCRIPTION
Complementing [recipes](https://pt.parceljs.org/recipes.html) documentation with the newer contents of english docs.

Fix markdown style in english documentation (using markdown lint to remove/add spaces when necessary).