### PR TITLE
Added info about running Parcel without installing it globally

### DIFF
--- a/src/i18n/en/docs/production.md
+++ b/src/i18n/en/docs/production.md
@@ -66,4 +66,4 @@ To make working with your project easier, you can add the script to package.json
 }
 ```
 
-You can then build your site with `npm run build`.
+You can then build your site with `npm run build` or `yarn build`.

--- a/src/i18n/en/docs/production.md
+++ b/src/i18n/en/docs/production.md
@@ -58,7 +58,7 @@ In this situation you won't have access to an alias for the Parcel CLI. To build
 node ./node_modules/parcel-bundler/bin/cli.js build entry.js
 ```
 
-To make working on your own machine easier, you can add the script to package.json.
+To make working with your project easier, you can add the script to package.json.
 
 ```json
 "scripts": {

--- a/src/i18n/en/docs/production.md
+++ b/src/i18n/en/docs/production.md
@@ -35,3 +35,25 @@ The file hash follows the following naming pattern: `<directory name>-<hash>.<ex
 In an effort to optimize production build performance, Parcel will try to determine the number of CPUs available at the machine running the build command so it can distribute the work accordingly. To do so, Parcel relies on the [physical-cpu-count](https://www.npmjs.com/package/physical-cpu-count) library.
 
 Be aware that this module assumes you have the [`lscpu`](http://manpages.courier-mta.org/htmlman1/lscpu.1.html) program available in your system.
+
+## If You Can't Install Parcel Globally
+
+Sometimes it's not possible to install Parcel globally e.g. if you're building on someone else's build agent. In this case, you can install and run Parcel as a local package.
+
+To install with Yarn:
+
+```bash
+yarn add parcel-bundler --dev
+```
+
+To install with NPM:
+
+```bash
+npm install parcel-bundler --save-dev
+```
+
+In this situation you won't have access to an alias for the Parcel CLI. To build your project use the following command:
+
+```bash
+node ./node_modules/parcel-bundler/bin/cli.js build entry.js
+```

--- a/src/i18n/en/docs/production.md
+++ b/src/i18n/en/docs/production.md
@@ -58,11 +58,11 @@ In this situation you won't have access to an alias for the Parcel CLI. To build
 node ./node_modules/parcel-bundler/bin/cli.js build entry.js
 ```
 
-To make working on your own machine easier, you can add your own script to package.json.
+To make working on your own machine easier, you can add the script to package.json.
 
 ```json
 "scripts": {
-    "build": "node ./node_modules/parcel-bundler/bin/cli.js build entry.js",
+    "build": "parcel build entry.js",
 }
 ```
 

--- a/src/i18n/en/docs/production.md
+++ b/src/i18n/en/docs/production.md
@@ -57,3 +57,13 @@ In this situation you won't have access to an alias for the Parcel CLI. To build
 ```bash
 node ./node_modules/parcel-bundler/bin/cli.js build entry.js
 ```
+
+To make working on your own machine easier, you can add your own script to package.json.
+
+```json
+"scripts": {
+    "build": "node ./node_modules/parcel-bundler/bin/cli.js build entry.js",
+}
+```
+
+You can then build your site with `npm run build`.


### PR DESCRIPTION
Hi! I was trying to use Parcel with Netlify's build agent and had to do it as described in my change to the Production doc. I wondered if this information might be useful for other people.

I'm sorry I'm not able to localise the text.