### PR TITLE
Add URL alias

### DIFF
--- a/now.json
+++ b/now.json
@@ -10,6 +10,7 @@
     "pt.parceljs.org",
     "ru.parceljs.org",
     "zh.parceljs.org",
-    "uk.parceljs.org"
+    "uk.parceljs.org",
+    "zh-tw.parceljs.org"
   ]
 }


### PR DESCRIPTION
`zh-tw.parceljs.org` is not available currently.

Try to update alias setting in this PR, but I'm not sure if this is cause of the problem.