### PR TITLE
Update for SCSS asset type page

### DIFF
--- a/src/i18n/en/docs/scss.md
+++ b/src/i18n/en/docs/scss.md
@@ -15,3 +15,7 @@ import './custom.scss'
 ```
 
 Dependencies in the SCSS files can be used with the `@import` statements.
+
+If you don't have `sass` module installed before running Parcel, Parcel will install it automatically for you.
+
+**Notes:** You can also use `node-sass` module for SCSS compilation. Using `node-sass` module will give you faster compilation. However, [an issue](https://github.com/parcel-bundler/parcel/issues/1836) has been reported using `node-sass` module with Parcel.

--- a/src/i18n/en/docs/scss.md
+++ b/src/i18n/en/docs/scss.md
@@ -5,7 +5,7 @@ _Supported extensions: `sass`, `scss`_
 SCSS compilation needs `sass` (JS version of `dart-sass`) module. To install it with npm:
 
 ```bash
-npm install sass
+npm install -D sass
 ```
 
 Once you have `sass` installed you can import SCSS files from JavaScript files.


### PR DESCRIPTION
Add additional information related SCSS asset type and modify the installation command for `sass` module. The module should be installed as a dev dependency instead of normal dependency.