### PR TITLE
Corrected name of .posthtmlrc.js

### DIFF
--- a/src/i18n/en/docs/html.md
+++ b/src/i18n/en/docs/html.md
@@ -33,7 +33,7 @@ Adding links to files that Parcel can compile (e.g. JavaScript, TypeScript, SCSS
 
 # PostHTML
 
-[PostHTML](https://github.com/posthtml/posthtml) is a tool for transforming HTML with plugins. You can configure PostHTML with Parcel by creating a configuration file using one of these names: `.posthtmlrc` (JSON), `posthtmlrc.js`, or `posthtml.config.js`.
+[PostHTML](https://github.com/posthtml/posthtml) is a tool for transforming HTML with plugins. You can configure PostHTML with Parcel by creating a configuration file using one of these names: `.posthtmlrc` (JSON), `.posthtmlrc.js`, or `posthtml.config.js`.
 
 Install plugins in your app:
 

--- a/src/i18n/es/docs/transforms.md
+++ b/src/i18n/es/docs/transforms.md
@@ -58,7 +58,7 @@ Para habilitar el uso de [CSS Modules](https://github.com/css-modules/css-module
 
 ## PostHTML
 
-[PostHTML](https://github.com/posthtml/posthtml) es una herramienta para transformar HTML con plugins. Puedes configurar PostHTML con Parcel creando un archivo de configuración usando uno de esos nombres: `.posthtmlrc` (JSON), `posthtmlrc.js`, o `posthtml.config.js`.
+[PostHTML](https://github.com/posthtml/posthtml) es una herramienta para transformar HTML con plugins. Puedes configurar PostHTML con Parcel creando un archivo de configuración usando uno de esos nombres: `.posthtmlrc` (JSON), `.posthtmlrc.js`, o `posthtml.config.js`.
 
 Instala los plugins que necesites en tu app:
 

--- a/src/i18n/fr/docs/html.md
+++ b/src/i18n/fr/docs/html.md
@@ -33,7 +33,7 @@ L'ajout de liens vers des fichiers que Parcel peut compiler (par exemple, JavaSc
 
 # PostHTML
 
-[PostHTML](https://github.com/posthtml/posthtml) est un outil pour transformer du HTML avec des plugins. Vous pouvez configurer PostHTML avec Parcel en créant un fichier de configuration en utilisant l'un de ces noms : `.posthtmlrc` (JSON), `posthtmlrc.js` ou `posthtml.config.js`.
+[PostHTML](https://github.com/posthtml/posthtml) est un outil pour transformer du HTML avec des plugins. Vous pouvez configurer PostHTML avec Parcel en créant un fichier de configuration en utilisant l'un de ces noms : `.posthtmlrc` (JSON), `.posthtmlrc.js` ou `posthtml.config.js`.
 
 Installez des plugins dans votre application :
 

--- a/src/i18n/it/docs/transforms.md
+++ b/src/i18n/it/docs/transforms.md
@@ -62,7 +62,7 @@ Affinché i CSS Modules funzionino correttamente con i file esistenti, è necess
 
 ## PostHTML
 
-[PostHTML](https://github.com/posthtml/posthtml) è un tool per convertire i file HTML con dei plugins. Puoi configurare PostHTML con Parcel creando un file di configurazione con questi nomi: `.posthtmlrc` (JSON), `posthtmlrc.js`, o `posthtml.config.js`.
+[PostHTML](https://github.com/posthtml/posthtml) è un tool per convertire i file HTML con dei plugins. Puoi configurare PostHTML con Parcel creando un file di configurazione con questi nomi: `.posthtmlrc` (JSON), `.posthtmlrc.js`, o `posthtml.config.js`.
 
 Installa i plugins nella tua app:
 

--- a/src/i18n/ko/docs/transforms.md
+++ b/src/i18n/ko/docs/transforms.md
@@ -75,7 +75,7 @@ module.exports = {
 
 ## PostHTML
 
-[PostHTML](https://github.com/posthtml/posthtml) 플러그인으로 HTML 을 변환하기 위한 도구입니다. `.posthtmlrc` (JSON), `posthtmlrc.js`, `posthtml.config.js` 중 하나의 파일을 작성하여 Parcel 에 PostHTML 을 설정할 수 있습니다.
+[PostHTML](https://github.com/posthtml/posthtml) 플러그인으로 HTML 을 변환하기 위한 도구입니다. `.posthtmlrc` (JSON), `.posthtmlrc.js`, `posthtml.config.js` 중 하나의 파일을 작성하여 Parcel 에 PostHTML 을 설정할 수 있습니다.
 
 플러그인을 앱에 설치 하세요.
 

--- a/src/i18n/pl/docs/transforms.md
+++ b/src/i18n/pl/docs/transforms.md
@@ -58,7 +58,7 @@ Moduły CSS są włączane w nieco inny sposób za pomocą klucza `modules` na n
 
 ## PostHTML
 
-[PostHTML](https://github.com/posthtml/posthtml) to narzędzie do transformowania HTML za pomocą wtyczek. Możesz skonfigurować PostHTML z Parcel tworząc plik konfiguracyjny o jednej z nazw: `.posthtmlrc` (JSON), `posthtmlrc.js` lub `posthtml.config.js`.
+[PostHTML](https://github.com/posthtml/posthtml) to narzędzie do transformowania HTML za pomocą wtyczek. Możesz skonfigurować PostHTML z Parcel tworząc plik konfiguracyjny o jednej z nazw: `.posthtmlrc` (JSON), `.posthtmlrc.js` lub `posthtml.config.js`.
 
 Zainstaluj wtyczki w aplikacji wykonując:
 

--- a/src/i18n/pt/docs/html.md
+++ b/src/i18n/pt/docs/html.md
@@ -20,7 +20,7 @@ Arquivos HTML são frequentemente utilizados como ponto de entrada para o Parcel
 
 # PostHTML
 
-[PostHTML](https://github.com/posthtml/posthtml) é uma ferramenta pra transformar HTML com plugins. Você pode configurar o PostHTML com o Parcel ao criar um arquivo de configuração com um desses nomes: `.posthtmlrc` (JSON), `posthtmlrc.js`, or `posthtml.config.js`.
+[PostHTML](https://github.com/posthtml/posthtml) é uma ferramenta pra transformar HTML com plugins. Você pode configurar o PostHTML com o Parcel ao criar um arquivo de configuração com um desses nomes: `.posthtmlrc` (JSON), `.posthtmlrc.js`, or `posthtml.config.js`.
 
 Instale plugins na sua aplicação:
 

--- a/src/i18n/ru/docs/transforms.md
+++ b/src/i18n/ru/docs/transforms.md
@@ -62,7 +62,7 @@ last 2 versions
 
 ## PostHTML
 
-[PostHTML](https://github.com/posthtml/posthtml) - инструмент для преобразования HTML с помощью плагинов. Вы можете настроить PostHTML с помощью Parcel, создав конфигурационный файл, используя одно из следующих имен: `.posthtmlrc` (JSON), `posthtmlrc.js` или `posthtml.config.js`.
+[PostHTML](https://github.com/posthtml/posthtml) - инструмент для преобразования HTML с помощью плагинов. Вы можете настроить PostHTML с помощью Parcel, создав конфигурационный файл, используя одно из следующих имен: `.posthtmlrc` (JSON), `.posthtmlrc.js` или `posthtml.config.js`.
 
 Установка плагинов в приложении:
 

--- a/src/i18n/uk/docs/transforms.md
+++ b/src/i18n/uk/docs/transforms.md
@@ -58,7 +58,7 @@ last 2 versions
 
 ## PostHTML
 
-[PostHTML](https://github.com/posthtml/posthtml) - інструмент для перетворення HTML за допомогою плагінів. Ви можете налаштувати PostHTML за допомогою Parcel, створивши конфігураційний файл, використовуючи одне з наступних імен: `.posthtmlrc` (JSON),`posthtmlrc.js` або `posthtml.config.js`.
+[PostHTML](https://github.com/posthtml/posthtml) - інструмент для перетворення HTML за допомогою плагінів. Ви можете налаштувати PostHTML за допомогою Parcel, створивши конфігураційний файл, використовуючи одне з наступних імен: `.posthtmlrc` (JSON),`.posthtmlrc.js` або `posthtml.config.js`.
 
 Установка плагінів в додатку:
 

--- a/src/i18n/zh-tw/docs/html.md
+++ b/src/i18n/zh-tw/docs/html.md
@@ -38,7 +38,7 @@ HTML 中引入的連結將會被改寫使其可連結至輸出的檔案。
 
 # PostHTML
 
-[PostHTML](https://github.com/posthtml/posthtml) 是款支援外掛擴充的 HTML 轉換工具。若要在 Parcel 中使用 PostHTML ，你可以建立下列其中一個設定檔：`.posthtmlrc` (JSON)、`posthtmlrc.js` 或 `posthtml.config.js`。
+[PostHTML](https://github.com/posthtml/posthtml) 是款支援外掛擴充的 HTML 轉換工具。若要在 Parcel 中使用 PostHTML ，你可以建立下列其中一個設定檔：`.posthtmlrc` (JSON)、`.posthtmlrc.js` 或 `posthtml.config.js`。
 
 首先在你的 app 中安裝外掛：
 

--- a/src/i18n/zh/docs/transforms.md
+++ b/src/i18n/zh/docs/transforms.md
@@ -75,7 +75,7 @@ module.exports = {
 
 ## PostHTML
 
-[PostHTML](https://github.com/posthtml/posthtml) 是一个通过插件转换 HTML 的工具。你可以使用这些名称之一创建配置，从而达到使用 Parcel 配置 PostHTML 的目的： `.posthtmlrc` (JSON) ，`posthtmlrc.js` ，或者 `posthtml.config.js`。
+[PostHTML](https://github.com/posthtml/posthtml) 是一个通过插件转换 HTML 的工具。你可以使用这些名称之一创建配置，从而达到使用 Parcel 配置 PostHTML 的目的： `.posthtmlrc` (JSON) ，`.posthtmlrc.js` ，或者 `posthtml.config.js`。
 
 在你的应用程序中安装 plugin ：
 


### PR DESCRIPTION
The documented `posthtmlrc.js` does not work; only when `.posthtmlrc.js` is used is the configuration recognised.

This is confirmed by the source code for `parcel` at https://github.com/parcel-bundler/parcel/blob/master/packages/core/parcel-bundler/src/transforms/posthtml.js#L29