### PR TITLE
Update description of node_modules handling

### DIFF
--- a/src/i18n/en/docs/transforms.md
+++ b/src/i18n/en/docs/transforms.md
@@ -1,5 +1,50 @@
 # 🐠 Transforms
 
-While many bundlers require you to install and configure plugins to transform assets, Parcel has support for many common transforms and transpilers built in out of the box. You can transform JavaScript using [Babel](https://babeljs.io), CSS using [PostCSS](http://postcss.org), and HTML using [PostHTML](https://github.com/posthtml/posthtml). Parcel automatically runs these transforms when it finds a configuration file (e.g. `.babelrc`, `.postcssrc`) in a module.
+While many bundlers require you to install and configure plugins to transform assets, Parcel has support for many common transforms and transpilers built in out of the box. You can transform JavaScript using [Babel](https://babeljs.io), CSS using [PostCSS](http://postcss.org), and HTML using [PostHTML](https://github.com/posthtml/posthtml). Parcel automatically runs these transforms when it finds a configuration file (e.g. `.babelrc`, `.postcssrc`) in a module. (In addition to any transforms specified in `.babelrc`, Parcel always uses Babel on all modules to compile modern JavaScript into a form supported by browsers. See the [JavaScript/Default Babel Transforms](javascript.html#default-babel-transforms) section for more information.)
 
-This even works in third-party `node_modules`: if a configuration file is published as part of the package, the transform is automatically turned on for that module only. This keeps bundling fast since only modules that need to be transformed are processed. It also means that you don't need to manually configure the transforms to include and exclude certain files, or know how third party code is built in order to use it in your application.
+## Third-Party Modules
+
+Configuration files (such as `.babelrc`) inside third-party `node_modules` will be ignored by default. However, if the module's directory is symlinked (as is common in some monorepo conventions) and the module's `package.json` has the `source` field set, then configuration files in the module's directory will be respected. Here are the types of values supported by the `source` field:
+
+* Treat all files as source code, don't change the resolution
+
+```json
+{
+  "main": "foo.js",
+  "source": true
+}
+```
+
+* When compiling from source, use bar.js as the entry point
+
+```json
+{
+  "main": "foo.js",
+  "source": "bar.js"
+}
+```
+
+* When compiling from source, alias specific files
+
+```json
+{
+  "main": "foo.js",
+  "source": {
+    "./foo.js": "./bar.js",
+    "./baz.js": "./yay.js"
+  }
+}
+```
+
+* When compiling from source, alias using glob patterns
+
+```json
+{
+  "main": "foo.js",
+  "source": {
+    "./lib/**": "./src/$1"
+  }
+}
+```
+
+The last example allows you to replace your entire lib directory with src so import 'my-module/lib/test.js' would resolve to 'my-module/src/test.js'. You could also use a top-level catch-all pattern like `"**": "./src/$1"` for packages like lodash that have many files in the root to replace (e.g. lodash/cloneDeep with lodash/src/cloneDeep).

--- a/src/i18n/en/docs/transforms.md
+++ b/src/i18n/en/docs/transforms.md
@@ -4,7 +4,7 @@ While many bundlers require you to install and configure plugins to transform as
 
 ## Third-Party Modules
 
-Configuration files (such as `.babelrc`) inside third-party `node_modules` will be ignored by default. However, if the module's directory is symlinked (as is common in some monorepo conventions) and the module's `package.json` has the `source` field set, then configuration files in the module's directory will be respected. Here are the types of values supported by the `source` field:
+Configuration files (such as `.babelrc`) will not be applied to files inside third-party `node_modules` by default. However, if the module's directory is symlinked (as is common in some monorepo conventions) and the module's `package.json` has the `source` field set, then configuration files inside the module's directory will be respected. Here are the types of values supported by the `source` field:
 
 * Treat all files as source code, don't change the resolution
 


### PR DESCRIPTION
* Updates the Transforms page to be consistent with https://github.com/parcel-bundler/parcel/pull/559 and https://github.com/parcel-bundler/parcel/pull/1101.
* Adds a link from the Transforms page to the Babel section of the JavaScript page. (I originally arrived to the Parcel documentation specifically curious about how Parcel handled Babel, and the "Transforms" page seemed to be the page most specifically about Babel, so I incorrectly assumed the rest of the documentation didn't have anything more detailed about Babel. I think this link would have helped me out.)