### PR TITLE
Nit: Improve wording of sourceMaps option

### DIFF
--- a/src/i18n/en/docs/api.md
+++ b/src/i18n/en/docs/api.md
@@ -35,7 +35,7 @@ const options = {
   logLevel: 3, // 3 = log everything, 2 = log warnings & errors, 1 = log errors
   hmr: true, //Enable or disable HMR while watching
   hmrPort: 0, // The port the HMR socket runs on, defaults to a random free port (0 in node.js resolves to a random free port)
-  sourceMaps: true, // Enable or disable sourcemaps, defaults to enabled (not supported in minified builds yet)
+  sourceMaps: true, // Enable or disable sourcemaps, defaults to enabled (minified builds currently always create sourcemaps)
   hmrHostname: '', // A hostname for hot module reload, default to ''
   detailedReport: false // Prints a detailed report of the bundles, assets, filesizes and times, defaults to false, reports are only printed if watch is disabled
 };


### PR DESCRIPTION
The old wording of this line made it sound like sourcemaps weren't supported in minified builds.

(Normally I'd try to make my PRs more substantial, but this line nearly scared me off of Parcel before I thought to try it, so I figured tweaking it was important enough for a small PR.)