### PR TITLE
Scroll activeLink into view

### DIFF
--- a/src/i18n/en/layout/page.html
+++ b/src/i18n/en/layout/page.html
@@ -159,6 +159,7 @@
         var activeLink = document.querySelector('a[href="' + pathname + '"]')
 
         activeLink.classList.add('selected')
+        if (activeLink.scrollIntoView) activeLink.scrollIntoView()
 
         docsearch({
           apiKey: '8b6be780425a72d1a1683abea2636778',

--- a/src/i18n/es/layout/page.html
+++ b/src/i18n/es/layout/page.html
@@ -1,98 +1,108 @@
 <!DOCTYPE html>
 <html lang="es">
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>{{title}}</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link type="text/css" rel="stylesheet" href="assets/style.css" />
-  <link type="text/css" rel="stylesheet" href="assets/pilcrow.css" />
-  <link type="text/css" rel="stylesheet" href="assets/hljs-github.min.css"/>
-  <link rel="shortcut icon" href="assets/favicon.ico" type="image/x-icon">
-  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-110647385-1"></script>
-  <script type="text/javascript">
-    var LANGUAGE = 'es';
-    
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'UA-110647385-1');
-  </script>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
-</head>
-<body>
-  <header>
-    <a class="logo" href="/">
-      <img class="parcel" src="assets/parcel.png" srcset="assets/parcel@2x.png 2x, assets/parcel@3x.png 3x" height="30">
-      <img class="type" src="assets/logo.svg" alt="Parcel">
-    </a>
-    <div class="links">
-      <input type="text" id="search-input" class="search-input" placeholder="Buscar..." />
-      <form class="languages">
-        <select class="language-dropdown" onchange="location = this.options[this.selectedIndex].value;">
-          <option class="en" value="https://en.parceljs.org">English</option>
-          <option class="es" value="https://es.parceljs.org" selected>Español</option>
-          <option class="fr" value="https://fr.parceljs.org">Français</option>
-          <option class="it" value="https://it.parceljs.org">Italiano</option>
-          <option class="ko" value="https://ko.parceljs.org">한국어</option>
-          <option class="pl" value="https://pl.parceljs.org">Polskie</option>
-          <option class="pt" value="https://pt.parceljs.org">Português</option>
-          <option class="ru" value="https://ru.parceljs.org">Русский</option>
-          <option class="uk" value="https://uk.parceljs.org">Українська</option>
-          <option class="zh" value="https://zh.parceljs.org">简体中文</option>
-          <option class="zh-tw" value="https://zh-tw.parceljs.org">繁體中文</option>
-        </select>
-      </form>
-      <a href="https://github.com/parcel-bundler/parcel" target="_blank">GitHub</a>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{{title}}</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link type="text/css" rel="stylesheet" href="assets/style.css" />
+    <link type="text/css" rel="stylesheet" href="assets/pilcrow.css" />
+    <link type="text/css" rel="stylesheet" href="assets/hljs-github.min.css" />
+    <link rel="shortcut icon" href="assets/favicon.ico" type="image/x-icon" />
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-110647385-1"></script>
+    <script type="text/javascript">
+      var LANGUAGE = 'es'
+
+      window.dataLayer = window.dataLayer || []
+      function gtag() {
+        dataLayer.push(arguments)
+      }
+      gtag('js', new Date())
+      gtag('config', 'UA-110647385-1')
+    </script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
+  </head>
+  <body>
+    <header>
+      <a class="logo" href="/">
+        <img
+          class="parcel"
+          src="assets/parcel.png"
+          srcset="assets/parcel@2x.png 2x, assets/parcel@3x.png 3x"
+          height="30"
+        />
+        <img class="type" src="assets/logo.svg" alt="Parcel" />
+      </a>
+      <div class="links">
+        <input type="text" id="search-input" class="search-input" placeholder="Buscar..." />
+        <form class="languages">
+          <select class="language-dropdown" onchange="location = this.options[this.selectedIndex].value;">
+            <option class="en" value="https://en.parceljs.org">English</option>
+            <option class="es" value="https://es.parceljs.org" selected>Español</option>
+            <option class="fr" value="https://fr.parceljs.org">Français</option>
+            <option class="it" value="https://it.parceljs.org">Italiano</option>
+            <option class="ko" value="https://ko.parceljs.org">한국어</option>
+            <option class="pl" value="https://pl.parceljs.org">Polskie</option>
+            <option class="pt" value="https://pt.parceljs.org">Português</option>
+            <option class="ru" value="https://ru.parceljs.org">Русский</option>
+            <option class="uk" value="https://uk.parceljs.org">Українська</option>
+            <option class="zh" value="https://zh.parceljs.org">简体中文</option>
+            <option class="zh-tw" value="https://zh-tw.parceljs.org">繁體中文</option>
+          </select>
+        </form>
+        <a href="https://github.com/parcel-bundler/parcel" target="_blank">GitHub</a>
+      </div>
+    </header>
+    <div class="content">
+      <nav>
+        <ul>
+          <li><a href="getting_started.html">🚀 Empezar</a></li>
+          <li><a href="assets.html">📦 Recursos</a></li>
+          <li><a href="transforms.html">🐠 Conversiones</a></li>
+          <li><a href="code_splitting.html">✂️ Separación de código</a></li>
+          <li><a href="hmr.html">🔥 Reemplazo de módulos en caliente</a></li>
+          <li><a href="production.html">✨ Producción</a></li>
+          <li><a href="recipes.html">🍰 Recetas</a></li>
+        </ul>
+        <h3>Advanced</h3>
+        <ul>
+          <li><a href="how_it_works.html">🛠 Cómo funciona</a></li>
+          <li><a href="asset_types.html">📝 Tipos de recursos</a></li>
+          <li><a href="packagers.html">📦 Empaquetadores</a></li>
+          <li><a href="plugins.html">🔌 plugins</a></li>
+        </ul>
+      </nav>
+      <main>
+        {{~> content}}
+
+        <h2>Help us improve the docs</h2>
+        <p>
+          If something is missing or not entirely clear, please
+          <a href="https://github.com/parcel-bundler/website/issues">file an issue on the website repository</a> or
+          <a href="https://github.com/parcel-bundler/website/edit/master/src/i18n/{{language}}/docs/{{relative}}"
+            >edit this page</a
+          >.
+        </p>
+      </main>
     </div>
-  </header>
-  <div class="content">
-    <nav>
-      <ul>
-        <li><a href="getting_started.html">🚀 Empezar</a></li>
-        <li><a href="assets.html">📦 Recursos</a></li>
-        <li><a href="transforms.html">🐠 Conversiones</a></li>
-        <li><a href="code_splitting.html">✂️ Separación de código</a></li>
-        <li><a href="hmr.html">🔥 Reemplazo de módulos en caliente</a></li>
-        <li><a href="production.html">✨ Producción</a></li>
-        <li><a href="recipes.html">🍰 Recetas</a></li>
-      </ul>
-      <h3>Advanced</h3>
-      <ul>
-        <li><a href="how_it_works.html">🛠 Cómo funciona</a></li>
-        <li><a href="asset_types.html">📝 Tipos de recursos</a></li>
-        <li><a href="packagers.html">📦 Empaquetadores</a></li>
-        <li><a href="plugins.html">🔌 plugins</a></li>
-      </ul>
-    </nav>
-    <main>
-      {{~> content}}
+    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
+    <script type="text/javascript">
+      ;(function() {
+        var pathname = window.location.pathname.substr(1)
+        var activeLink = document.querySelector('a[href="' + pathname + '"]')
 
-      <h2>Help us improve the docs</h2>
-      <p>If something is missing or not entirely clear, please 
-          <a href="https://github.com/parcel-bundler/website/issues">file an issue on the website repository</a> 
-          or <a href="https://github.com/parcel-bundler/website/edit/master/src/i18n/{{language}}/docs/{{relative}}">edit this page</a>.</p>
-    </main>
-  </div>
-  <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
-  <script type="text/javascript">
-    (function () {
-      var pathname = window.location.pathname.substr(1);
-      var activeLink = document.querySelector('a[href="' + pathname + '"]');
+        activeLink.classList.add('selected')
+        if (activeLink.scrollIntoView) activeLink.scrollIntoView()
 
-      activeLink.classList.add('selected');
-
-      docsearch({
-        apiKey: '8b6be780425a72d1a1683abea2636778',
-        indexName: 'parceljs',
-        inputSelector: '#search-input',
-        algoliaOptions: {
-          'facetFilters': [
-            `lang:${LANGUAGE}`
-          ]
-        }
-      });
-    })();
-  </script>
-</body>
+        docsearch({
+          apiKey: '8b6be780425a72d1a1683abea2636778',
+          indexName: 'parceljs',
+          inputSelector: '#search-input',
+          algoliaOptions: {
+            facetFilters: [`lang:${LANGUAGE}`]
+          }
+        })
+      })()
+    </script>
+  </body>
 </html>

--- a/src/i18n/fr/layout/page.html
+++ b/src/i18n/fr/layout/page.html
@@ -1,166 +1,177 @@
 <!DOCTYPE html>
 <html lang="fr">
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>{{title}}</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link type="text/css" rel="stylesheet" href="assets/style.css" />
-  <link type="text/css" rel="stylesheet" href="assets/pilcrow.css" />
-  <link type="text/css" rel="stylesheet" href="assets/hljs-github.min.css"/>
-  <link rel="shortcut icon" href="assets/favicon.ico" type="image/x-icon">
-  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-110647385-1"></script>
-  <script type="text/javascript">
-    var LANGUAGE = 'fr';
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{{title}}</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link type="text/css" rel="stylesheet" href="assets/style.css" />
+    <link type="text/css" rel="stylesheet" href="assets/pilcrow.css" />
+    <link type="text/css" rel="stylesheet" href="assets/hljs-github.min.css" />
+    <link rel="shortcut icon" href="assets/favicon.ico" type="image/x-icon" />
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-110647385-1"></script>
+    <script type="text/javascript">
+      var LANGUAGE = 'fr'
 
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'UA-110647385-1');
-  </script>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
-</head>
-<body>
-  <header>
-    <a class="logo" href="/">
-      <img class="parcel" src="assets/parcel.png" srcset="assets/parcel@2x.png 2x, assets/parcel@3x.png 3x" height="30">
-      <img class="type" src="assets/logo.svg" alt="Parcel">
-    </a>
-    <div class="links">
-      <input type="text" id="search-input" class="search-input" placeholder="Chercher..." />
-      <form class="languages">
-        <select class="language-dropdown" onchange="location = this.options[this.selectedIndex].value;">
-          <option class="en" value="https://en.parceljs.org">English</option>
-          <option class="es" value="https://es.parceljs.org">Español</option>
-          <option class="fr" value="https://fr.parceljs.org" selected>Français</option>
-          <option class="it" value="https://it.parceljs.org">Italiano</option>
-          <option class="ko" value="https://ko.parceljs.org">한국어</option>
-          <option class="pl" value="https://pl.parceljs.org">Polskie</option>
-          <option class="pt" value="https://pt.parceljs.org">Português</option>
-          <option class="ru" value="https://ru.parceljs.org">Русский</option>
-          <option class="uk" value="https://uk.parceljs.org">Українська</option>
-          <option class="zh" value="https://zh.parceljs.org">简体中文</option>
-          <option class="zh-tw" value="https://zh-tw.parceljs.org">繁體中文</option>
-        </select>
-      </form>
-      <a href="https://github.com/parcel-bundler/parcel" target="_blank">GitHub</a>
+      window.dataLayer = window.dataLayer || []
+      function gtag() {
+        dataLayer.push(arguments)
+      }
+      gtag('js', new Date())
+      gtag('config', 'UA-110647385-1')
+    </script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
+  </head>
+  <body>
+    <header>
+      <a class="logo" href="/">
+        <img
+          class="parcel"
+          src="assets/parcel.png"
+          srcset="assets/parcel@2x.png 2x, assets/parcel@3x.png 3x"
+          height="30"
+        />
+        <img class="type" src="assets/logo.svg" alt="Parcel" />
+      </a>
+      <div class="links">
+        <input type="text" id="search-input" class="search-input" placeholder="Chercher..." />
+        <form class="languages">
+          <select class="language-dropdown" onchange="location = this.options[this.selectedIndex].value;">
+            <option class="en" value="https://en.parceljs.org">English</option>
+            <option class="es" value="https://es.parceljs.org">Español</option>
+            <option class="fr" value="https://fr.parceljs.org" selected>Français</option>
+            <option class="it" value="https://it.parceljs.org">Italiano</option>
+            <option class="ko" value="https://ko.parceljs.org">한국어</option>
+            <option class="pl" value="https://pl.parceljs.org">Polskie</option>
+            <option class="pt" value="https://pt.parceljs.org">Português</option>
+            <option class="ru" value="https://ru.parceljs.org">Русский</option>
+            <option class="uk" value="https://uk.parceljs.org">Українська</option>
+            <option class="zh" value="https://zh.parceljs.org">简体中文</option>
+            <option class="zh-tw" value="https://zh-tw.parceljs.org">繁體中文</option>
+          </select>
+        </form>
+        <a href="https://github.com/parcel-bundler/parcel" target="_blank">GitHub</a>
+      </div>
+    </header>
+    <div class="content">
+      <nav>
+        <h3>Commencer</h3>
+        <ul>
+          <li><a href="getting_started.html">🚀 Commencer</a></li>
+          <li><a href="assets.html">📦 Ressources</a></li>
+          <li><a href="transforms.html">🐠 Transformations</a></li>
+        </ul>
+        <h3>Fonctionnalités</h3>
+        <ul>
+          <li><a href="code_splitting.html">✂️ Découpage du code</a></li>
+          <li><a href="hmr.html">🔥 Remplacement de module à chaud</a></li>
+          <li><a href="production.html">✨ Production</a></li>
+          <li><a href="cli.html">🖥 CLI</a></li>
+          <li><a href="recipes.html">🍰 Recettes</a></li>
+          <li><a href="env.html">🌳 Variables d'environnement</a></li>
+          <li><a href="module_resolution.html">📔 Résolution de module</a></li>
+        </ul>
+        <h3>📦 Types de ressources</h3>
+        <ul>
+          <li>
+            <a href="javascript.html"><img src="assets/icon-javascript.svg" />Javascript</a>
+          </li>
+          <li>
+            <a href="reasonML.html"><img src="assets/icon-reason-ml.svg" />ReasonML</a>
+          </li>
+          <li>
+            <a href="css.html"><img src="assets/icon-css.svg" />CSS</a>
+          </li>
+          <li>
+            <a href="scss.html"><img src="assets/icon-sass.svg" />SCSS</a>
+          </li>
+          <li>
+            <a href="less.html"><img src="assets/icon-less.svg" />LESS</a>
+          </li>
+          <li>
+            <a href="stylus.html"><img src="assets/icon-stylus.svg" />Stylus</a>
+          </li>
+          <li>
+            <a href="html.html"><img src="assets/icon-html5.svg" />HTML</a>
+          </li>
+          <li>
+            <a href="typeScript.html"><img src="assets/icon-typescript.svg" />TypeScript</a>
+          </li>
+          <li>
+            <a href="coffeeScript.html"><img src="assets/icon-coffeescript.svg" />CoffeeScript</a>
+          </li>
+          <li>
+            <a href="vue.html"><img src="assets/icon-vuejs.svg" />Vue</a>
+          </li>
+          <li>
+            <a href="json.html"><img src="assets/icon-json.svg" />JSON</a>
+          </li>
+          <li>
+            <a href="graphQL.html"><img src="assets/icon-graphql.svg" />GraphQL</a>
+          </li>
+          <li>
+            <a href="rust.html"><img src="assets/icon-rust.svg" />Rust</a>
+          </li>
+          <li>
+            <a href="webAssembly.html"><img src="assets/icon-webassembly.svg" />WebAssembly</a>
+          </li>
+          <li>
+            <a href="yaml.html"><img src="assets/icon-yaml.svg" />YAML</a>
+          </li>
+          <li>
+            <a href="toml.html"><img src="assets/icon-toml.svg" />TOML</a>
+          </li>
+          <li>
+            <a href="openGL.html"><img src="assets/icon-openGL.svg" />OpenGL</a>
+          </li>
+          <li>
+            <a href="pug.html"><img src="assets/icon-pug.svg" />Pug</a>
+          </li>
+          <li><a href="webManifest.html">WebManifest</a></li>
+        </ul>
+        <h3>Avancée</h3>
+        <ul>
+          <li><a href="how_it_works.html">🛠 Comment ça marche</a></li>
+          <li><a href="asset_types.html">📝 Types de ressources</a></li>
+          <li><a href="plugins.html">🔌 Plugins</a></li>
+          <li><a href="packagers.html">📦 Packagers</a></li>
+          <li><a href="api.html">📚 API</a></li>
+        </ul>
+      </nav>
+      <main>
+        {{~> content}}
+
+        <h2>Aidez-nous à améliorer la documentation</h2>
+        <p>
+          Si quelque chose manque ou n'est pas tout à fait clair, veuillez
+          <a href="https://github.com/parcel-bundler/website/issues"
+            >enregistrer une issue sur le dépôt du site web (en anglais)</a
+          >
+          ou
+          <a href="https://github.com/parcel-bundler/website/edit/master/src/i18n/{{language}}/docs/{{relative}}"
+            >modifier cette page</a
+          >.
+        </p>
+      </main>
     </div>
-  </header>
-  <div class="content">
-    <nav>
-      <h3>Commencer</h3>
-      <ul>
-        <li><a href="getting_started.html">🚀 Commencer</a></li>
-        <li><a href="assets.html">📦 Ressources</a></li>
-        <li><a href="transforms.html">🐠 Transformations</a></li>
-      </ul>
-      <h3>Fonctionnalités</h3>
-      <ul>
-        <li><a href="code_splitting.html">✂️ Découpage du code</a></li>
-        <li><a href="hmr.html">🔥 Remplacement de module à chaud</a></li>
-        <li><a href="production.html">✨ Production</a></li>
-        <li><a href="cli.html">🖥 CLI</a></li>
-        <li><a href="recipes.html">🍰 Recettes</a></li>
-        <li><a href="env.html">🌳 Variables d'environnement</a></li>
-        <li><a href="module_resolution.html">📔 Résolution de module</a></li>
-      </ul>
-      <h3>📦 Types de ressources</h3>
-      <ul>
-          <li>
-              <a href="javascript.html"><img src="assets/icon-javascript.svg">Javascript</a>
-          </li>
-          <li>
-              <a href="reasonML.html"><img src="assets/icon-reason-ml.svg">ReasonML</a>
-          </li>
-          <li>
-              <a href="css.html"><img src="assets/icon-css.svg">CSS</a>
-          </li>
-          <li>
-              <a href="scss.html"><img src="assets/icon-sass.svg">SCSS</a>
-          </li>
-          <li>
-              <a href="less.html"><img src="assets/icon-less.svg">LESS</a>
-          </li>
-          <li>
-              <a href="stylus.html"><img src="assets/icon-stylus.svg">Stylus</a>
-          </li>
-          <li>
-              <a href="html.html"><img src="assets/icon-html5.svg">HTML</a>
-          </li>
-          <li>
-              <a href="typeScript.html"><img src="assets/icon-typescript.svg">TypeScript</a>
-          </li>
-          <li>
-              <a href="coffeeScript.html"><img src="assets/icon-coffeescript.svg">CoffeeScript</a>
-          </li>
-          <li>
-              <a href="vue.html"><img src="assets/icon-vuejs.svg">Vue</a>
-          </li>
-          <li>
-              <a href="json.html"><img src="assets/icon-json.svg">JSON</a>
-          </li>
-          <li>
-              <a href="graphQL.html"><img src="assets/icon-graphql.svg">GraphQL</a>
-          </li>
-          <li>
-              <a href="rust.html"><img src="assets/icon-rust.svg">Rust</a>
-          </li>
-          <li>
-              <a href="webAssembly.html"><img src="assets/icon-webassembly.svg">WebAssembly</a>
-          </li>
-          <li>
-              <a href="yaml.html"><img src="assets/icon-yaml.svg">YAML</a>
-          </li>
-          <li>
-              <a href="toml.html"><img src="assets/icon-toml.svg">TOML</a>
-          </li>
-          <li>
-              <a href="openGL.html"><img src="assets/icon-openGL.svg">OpenGL</a>
-          </li>
-          <li>
-              <a href="pug.html"><img src="assets/icon-pug.svg">Pug</a>
-          </li>
-          <li>
-              <a href="webManifest.html">WebManifest</a>
-          </li>
-      </ul>
-      <h3>Avancée</h3>
-      <ul>
-        <li><a href="how_it_works.html">🛠 Comment ça marche</a></li>
-        <li><a href="asset_types.html">📝 Types de ressources</a></li>
-        <li><a href="plugins.html">🔌 Plugins</a></li>
-        <li><a href="packagers.html">📦 Packagers</a></li>
-        <li><a href="api.html">📚 API</a></li>
-      </ul>
-    </nav>
-    <main>
-      {{~> content}}
+    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
+    <script type="text/javascript">
+      ;(function() {
+        var pathname = window.location.pathname.substr(1)
+        var activeLink = document.querySelector('a[href="' + pathname + '"]')
 
-      <h2>Aidez-nous à améliorer la documentation</h2>
-      <p>Si quelque chose manque ou n'est pas tout à fait clair, veuillez 
-          <a href="https://github.com/parcel-bundler/website/issues">enregistrer une issue sur le dépôt du site web (en anglais)</a> 
-          ou <a href="https://github.com/parcel-bundler/website/edit/master/src/i18n/{{language}}/docs/{{relative}}">modifier cette page</a>.</p>
-    </main>
-  </div>
-  <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
-  <script type="text/javascript">
-    (function () {
-      var pathname = window.location.pathname.substr(1);
-      var activeLink = document.querySelector('a[href="' + pathname + '"]');
+        activeLink.classList.add('selected')
+        if (activeLink.scrollIntoView) activeLink.scrollIntoView()
 
-      activeLink.classList.add('selected');
-
-      docsearch({
-        apiKey: '8b6be780425a72d1a1683abea2636778',
-        indexName: 'parceljs',
-        inputSelector: '#search-input',
-        algoliaOptions: {
-          'facetFilters': [
-            `lang:${LANGUAGE}`
-          ]
-        }
-      });
-    })();
-  </script>
-</body>
+        docsearch({
+          apiKey: '8b6be780425a72d1a1683abea2636778',
+          indexName: 'parceljs',
+          inputSelector: '#search-input',
+          algoliaOptions: {
+            facetFilters: [`lang:${LANGUAGE}`]
+          }
+        })
+      })()
+    </script>
+  </body>
 </html>

--- a/src/i18n/it/layout/page.html
+++ b/src/i18n/it/layout/page.html
@@ -1,100 +1,110 @@
 <!DOCTYPE html>
 <html lang="it">
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>{{title}}</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link type="text/css" rel="stylesheet" href="assets/style.css" />
-  <link type="text/css" rel="stylesheet" href="assets/pilcrow.css" />
-  <link type="text/css" rel="stylesheet" href="assets/hljs-github.min.css"/>
-  <link rel="shortcut icon" href="assets/favicon.ico" type="image/x-icon">
-  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-110647385-1"></script>
-  <script type="text/javascript">
-    var LANGUAGE = 'it';
-    
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'UA-110647385-1');
-  </script>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
-</head>
-<body>
-  <header>
-    <a class="logo" href="/">
-      <img class="parcel" src="assets/parcel.png" srcset="assets/parcel@2x.png 2x, assets/parcel@3x.png 3x" height="30">
-      <img class="type" src="assets/logo.svg" alt="Parcel">
-    </a>
-    <div class="links">
-      <input type="text" id="search-input" class="search-input" placeholder="Ricerca..." />
-      <form class="languages">
-        <select class="language-dropdown" onchange="location = this.options[this.selectedIndex].value;">
-          <option class="en" value="https://en.parceljs.org">English</option>
-          <option class="es" value="https://es.parceljs.org">Español</option>
-          <option class="fr" value="https://fr.parceljs.org">Français</option>
-          <option class="it" value="https://it.parceljs.org" selected>Italiano</option>
-          <option class="ko" value="https://ko.parceljs.org">한국어</option>
-          <option class="pl" value="https://pl.parceljs.org">Polskie</option>
-          <option class="pt" value="https://pt.parceljs.org">Português</option>
-          <option class="ru" value="https://ru.parceljs.org">Русский</option>
-          <option class="uk" value="https://uk.parceljs.org">Українська</option>
-          <option class="zh" value="https://zh.parceljs.org">简体中文</option>
-          <option class="zh-tw" value="https://zh-tw.parceljs.org">繁體中文</option>
-        </select>
-      </form>
-      <a href="https://github.com/parcel-bundler/parcel" target="_blank">GitHub</a>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{{title}}</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link type="text/css" rel="stylesheet" href="assets/style.css" />
+    <link type="text/css" rel="stylesheet" href="assets/pilcrow.css" />
+    <link type="text/css" rel="stylesheet" href="assets/hljs-github.min.css" />
+    <link rel="shortcut icon" href="assets/favicon.ico" type="image/x-icon" />
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-110647385-1"></script>
+    <script type="text/javascript">
+      var LANGUAGE = 'it'
+
+      window.dataLayer = window.dataLayer || []
+      function gtag() {
+        dataLayer.push(arguments)
+      }
+      gtag('js', new Date())
+      gtag('config', 'UA-110647385-1')
+    </script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
+  </head>
+  <body>
+    <header>
+      <a class="logo" href="/">
+        <img
+          class="parcel"
+          src="assets/parcel.png"
+          srcset="assets/parcel@2x.png 2x, assets/parcel@3x.png 3x"
+          height="30"
+        />
+        <img class="type" src="assets/logo.svg" alt="Parcel" />
+      </a>
+      <div class="links">
+        <input type="text" id="search-input" class="search-input" placeholder="Ricerca..." />
+        <form class="languages">
+          <select class="language-dropdown" onchange="location = this.options[this.selectedIndex].value;">
+            <option class="en" value="https://en.parceljs.org">English</option>
+            <option class="es" value="https://es.parceljs.org">Español</option>
+            <option class="fr" value="https://fr.parceljs.org">Français</option>
+            <option class="it" value="https://it.parceljs.org" selected>Italiano</option>
+            <option class="ko" value="https://ko.parceljs.org">한국어</option>
+            <option class="pl" value="https://pl.parceljs.org">Polskie</option>
+            <option class="pt" value="https://pt.parceljs.org">Português</option>
+            <option class="ru" value="https://ru.parceljs.org">Русский</option>
+            <option class="uk" value="https://uk.parceljs.org">Українська</option>
+            <option class="zh" value="https://zh.parceljs.org">简体中文</option>
+            <option class="zh-tw" value="https://zh-tw.parceljs.org">繁體中文</option>
+          </select>
+        </form>
+        <a href="https://github.com/parcel-bundler/parcel" target="_blank">GitHub</a>
+      </div>
+    </header>
+    <div class="content">
+      <nav>
+        <ul>
+          <li><a href="getting_started.html">🚀 Come Iniziare</a></li>
+          <li><a href="assets.html">📦 Assets</a></li>
+          <li><a href="transforms.html">🐠 Conversioni</a></li>
+          <li><a href="code_splitting.html">✂️ Code Splitting</a></li>
+          <li><a href="hmr.html">🔥 Hot Module Replacement</a></li>
+          <li><a href="production.html">✨ Produzione</a></li>
+          <li><a href="recipes.html">🍰 Ricette</a></li>
+          <li><a href="cli.html">🖥 CLI</a></li>
+        </ul>
+        <h3>Avanzate</h3>
+        <ul>
+          <li><a href="how_it_works.html">🛠 Come Funziona</a></li>
+          <li><a href="asset_types.html">📝 Tipi di Assets</a></li>
+          <li><a href="api.html">📚 API</a></li>
+          <li><a href="packagers.html">📦 Packagers</a></li>
+          <li><a href="plugins.html">🔌 Plugins</a></li>
+        </ul>
+      </nav>
+      <main>
+        {{~> content}}
+
+        <h2>Help us improve the docs</h2>
+        <p>
+          If something is missing or not entirely clear, please
+          <a href="https://github.com/parcel-bundler/website/issues">file an issue on the website repository</a> or
+          <a href="https://github.com/parcel-bundler/website/edit/master/src/i18n/{{language}}/docs/{{relative}}"
+            >edit this page</a
+          >.
+        </p>
+      </main>
     </div>
-  </header>
-  <div class="content">
-    <nav>
-      <ul>
-        <li><a href="getting_started.html">🚀 Come Iniziare</a></li>
-        <li><a href="assets.html">📦 Assets</a></li>
-        <li><a href="transforms.html">🐠 Conversioni</a></li>
-        <li><a href="code_splitting.html">✂️ Code Splitting</a></li>
-        <li><a href="hmr.html">🔥 Hot Module Replacement</a></li>
-        <li><a href="production.html">✨ Produzione</a></li>
-        <li><a href="recipes.html">🍰 Ricette</a></li>
-        <li><a href="cli.html">🖥 CLI</a></li>
-      </ul>
-      <h3>Avanzate</h3>
-      <ul>
-        <li><a href="how_it_works.html">🛠 Come Funziona</a></li>
-        <li><a href="asset_types.html">📝 Tipi di Assets</a></li>
-        <li><a href="api.html">📚 API</a></li>
-        <li><a href="packagers.html">📦 Packagers</a></li>
-        <li><a href="plugins.html">🔌 Plugins</a></li>
-      </ul>
-    </nav>
-    <main>
-      {{~> content}}
+    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
+    <script type="text/javascript">
+      ;(function() {
+        var pathname = window.location.pathname.substr(1)
+        var activeLink = document.querySelector('a[href="' + pathname + '"]')
 
-      <h2>Help us improve the docs</h2>
-      <p>If something is missing or not entirely clear, please 
-          <a href="https://github.com/parcel-bundler/website/issues">file an issue on the website repository</a> 
-          or <a href="https://github.com/parcel-bundler/website/edit/master/src/i18n/{{language}}/docs/{{relative}}">edit this page</a>.</p>
-    </main>
-  </div>
-  <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
-  <script type="text/javascript">
-    (function () {
-      var pathname = window.location.pathname.substr(1);
-      var activeLink = document.querySelector('a[href="' + pathname + '"]');
+        activeLink.classList.add('selected')
+        if (activeLink.scrollIntoView) activeLink.scrollIntoView()
 
-      activeLink.classList.add('selected');
-
-      docsearch({
-        apiKey: '8b6be780425a72d1a1683abea2636778',
-        indexName: 'parceljs',
-        inputSelector: '#search-input',
-        algoliaOptions: {
-          'facetFilters': [
-            `lang:${LANGUAGE}`
-          ]
-        }
-      });
-    })();
-  </script>
-</body>
+        docsearch({
+          apiKey: '8b6be780425a72d1a1683abea2636778',
+          indexName: 'parceljs',
+          inputSelector: '#search-input',
+          algoliaOptions: {
+            facetFilters: [`lang:${LANGUAGE}`]
+          }
+        })
+      })()
+    </script>
+  </body>
 </html>

--- a/src/i18n/ko/layout/page.html
+++ b/src/i18n/ko/layout/page.html
@@ -1,129 +1,111 @@
 <!DOCTYPE html>
 <html lang="ko">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{{title}}</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link type="text/css" rel="stylesheet" href="assets/style.css" />
+    <link type="text/css" rel="stylesheet" href="assets/pilcrow.css" />
+    <link type="text/css" rel="stylesheet" href="assets/hljs-github.min.css" />
+    <link rel="shortcut icon" href="assets/favicon.ico" type="image/x-icon" />
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-110647385-1"></script>
+    <script type="text/javascript">
+      var LANGUAGE = 'ko'
 
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>{{title}}</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link type="text/css" rel="stylesheet" href="assets/style.css" />
-  <link type="text/css" rel="stylesheet" href="assets/pilcrow.css" />
-  <link type="text/css" rel="stylesheet" href="assets/hljs-github.min.css"/>
-  <link rel="shortcut icon" href="assets/favicon.ico" type="image/x-icon">
-  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-110647385-1"></script>
-  <script type="text/javascript">
-    var LANGUAGE = 'ko';
-    
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'UA-110647385-1');
-  </script>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
-</head>
+      window.dataLayer = window.dataLayer || []
+      function gtag() {
+        dataLayer.push(arguments)
+      }
+      gtag('js', new Date())
+      gtag('config', 'UA-110647385-1')
+    </script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
+  </head>
 
-<body>
-  <header>
-    <a class="logo" href="/">
-      <img class="parcel" src="assets/parcel.png" srcset="assets/parcel@2x.png 2x, assets/parcel@3x.png 3x" height="30">
-      <img class="type" src="assets/logo.svg" alt="Parcel">
-    </a>
-    <div class="links">
-      <input type="text" id="search-input" class="search-input" placeholder="수색..." />
-      <form class="languages">
-        <select class="language-dropdown" onchange="location = this.options[this.selectedIndex].value;">
-          <option class="en" value="https://en.parceljs.org">English</option>
-          <option class="es" value="https://es.parceljs.org">Español</option>
-          <option class="fr" value="https://fr.parceljs.org">Français</option>
-          <option class="it" value="https://it.parceljs.org">Italiano</option>
-          <option class="ko" value="https://ko.parceljs.org" selected>한국어</option>
-          <option class="pl" value="https://pl.parceljs.org">Polskie</option>
-          <option class="pt" value="https://pt.parceljs.org">Português</option>
-          <option class="ru" value="https://ru.parceljs.org">Русский</option>
-          <option class="uk" value="https://uk.parceljs.org">Українська</option>
-          <option class="zh" value="https://zh.parceljs.org">简体中文</option>
-          <option class="zh-tw" value="https://zh-tw.parceljs.org">繁體中文</option>
-        </select>
-      </form>
-      <a href="https://github.com/parcel-bundler/parcel" target="_blank">GitHub</a>
+  <body>
+    <header>
+      <a class="logo" href="/">
+        <img
+          class="parcel"
+          src="assets/parcel.png"
+          srcset="assets/parcel@2x.png 2x, assets/parcel@3x.png 3x"
+          height="30"
+        />
+        <img class="type" src="assets/logo.svg" alt="Parcel" />
+      </a>
+      <div class="links">
+        <input type="text" id="search-input" class="search-input" placeholder="수색..." />
+        <form class="languages">
+          <select class="language-dropdown" onchange="location = this.options[this.selectedIndex].value;">
+            <option class="en" value="https://en.parceljs.org">English</option>
+            <option class="es" value="https://es.parceljs.org">Español</option>
+            <option class="fr" value="https://fr.parceljs.org">Français</option>
+            <option class="it" value="https://it.parceljs.org">Italiano</option>
+            <option class="ko" value="https://ko.parceljs.org" selected>한국어</option>
+            <option class="pl" value="https://pl.parceljs.org">Polskie</option>
+            <option class="pt" value="https://pt.parceljs.org">Português</option>
+            <option class="ru" value="https://ru.parceljs.org">Русский</option>
+            <option class="uk" value="https://uk.parceljs.org">Українська</option>
+            <option class="zh" value="https://zh.parceljs.org">简体中文</option>
+            <option class="zh-tw" value="https://zh-tw.parceljs.org">繁體中文</option>
+          </select>
+        </form>
+        <a href="https://github.com/parcel-bundler/parcel" target="_blank">GitHub</a>
+      </div>
+    </header>
+    <div class="content">
+      <nav>
+        <ul>
+          <li><a href="getting_started.html">🚀 시작하기</a></li>
+          <li><a href="assets.html">📦 애셋</a></li>
+          <li><a href="transforms.html">🐠 변환</a></li>
+          <li><a href="code_splitting.html">✂️ 코드 분할</a></li>
+          <li><a href="hmr.html">🔥 빠른 모듈 교체(HMR)</a></li>
+          <li><a href="production.html">✨ 프로덕션</a></li>
+          <li><a href="recipes.html">🍰 레시피</a></li>
+          <li><a href="cli.html">🖥 커맨드 라인 인터페이스</a></li>
+        </ul>
+        <h3>Advanced</h3>
+        <ul>
+          <li><a href="how_it_works.html">🛠 어떻게 동작하는가</a></li>
+          <li><a href="asset_types.html">📝 애셋 유형</a></li>
+          <li><a href="api.html">📚 API</a></li>
+          <li><a href="packagers.html">📦 패키저</a></li>
+          <li><a href="plugins.html">🔌 플러그인</a></li>
+        </ul>
+      </nav>
+      <main>
+        {{~> content}}
+
+        <h2>Help us improve the docs</h2>
+        <p>
+          If something is missing or not entirely clear, please
+          <a href="https://github.com/parcel-bundler/website/issues">file an issue on the website repository</a> or
+          <a href="https://github.com/parcel-bundler/website/edit/master/src/i18n/{{language}}/docs/{{relative}}"
+            >edit this page</a
+          >.
+        </p>
+      </main>
     </div>
-  </header>
-  <div class="content">
-    <nav>
-      <ul>
-        <li>
-          <a href="getting_started.html">🚀 시작하기</a>
-        </li>
-        <li>
-          <a href="assets.html">📦 애셋</a>
-        </li>
-        <li>
-          <a href="transforms.html">🐠 변환</a>
-        </li>
-        <li>
-          <a href="code_splitting.html">✂️ 코드 분할</a>
-        </li>
-        <li>
-          <a href="hmr.html">🔥 빠른 모듈 교체(HMR)</a>
-        </li>
-        <li>
-          <a href="production.html">✨ 프로덕션</a>
-        </li>
-        <li>
-          <a href="recipes.html">🍰 레시피</a>
-        </li>
-        <li>
-          <a href="cli.html">🖥 커맨드 라인 인터페이스</a>
-        </li>
-      </ul>
-      <h3>Advanced</h3>
-      <ul>
-        <li>
-          <a href="how_it_works.html">🛠 어떻게 동작하는가</a>
-        </li>
-        <li>
-          <a href="asset_types.html">📝 애셋 유형</a>
-        </li>
-        <li>
-          <a href="api.html">📚 API</a>
-        </li>
-        <li>
-          <a href="packagers.html">📦 패키저</a>
-        </li>
-        <li>
-          <a href="plugins.html">🔌 플러그인</a>
-        </li>
-      </ul>
-    </nav>
-    <main>
-      {{~> content}}
+    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
+    <script type="text/javascript">
+      ;(function() {
+        var pathname = window.location.pathname.substr(1)
+        var activeLink = document.querySelector('a[href="' + pathname + '"]')
 
-      <h2>Help us improve the docs</h2>
-      <p>If something is missing or not entirely clear, please 
-          <a href="https://github.com/parcel-bundler/website/issues">file an issue on the website repository</a> 
-          or <a href="https://github.com/parcel-bundler/website/edit/master/src/i18n/{{language}}/docs/{{relative}}">edit this page</a>.</p>
-    </main>
-  </div>
-  <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
-  <script type="text/javascript">
-    (function () {
-      var pathname = window.location.pathname.substr(1);
-      var activeLink = document.querySelector('a[href="' + pathname + '"]');
+        activeLink.classList.add('selected')
+        if (activeLink.scrollIntoView) activeLink.scrollIntoView()
 
-      activeLink.classList.add('selected');
-
-      docsearch({
-        apiKey: '8b6be780425a72d1a1683abea2636778',
-        indexName: 'parceljs',
-        inputSelector: '#search-input',
-        algoliaOptions: {
-          'facetFilters': [
-            `lang:${LANGUAGE}`
-          ]
-        }
-      });
-    })();
-  </script>
-</body>
-
+        docsearch({
+          apiKey: '8b6be780425a72d1a1683abea2636778',
+          indexName: 'parceljs',
+          inputSelector: '#search-input',
+          algoliaOptions: {
+            facetFilters: [`lang:${LANGUAGE}`]
+          }
+        })
+      })()
+    </script>
+  </body>
 </html>

--- a/src/i18n/pl/layout/page.html
+++ b/src/i18n/pl/layout/page.html
@@ -1,99 +1,108 @@
 <!DOCTYPE html>
 <html lang="pl">
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>{{title}}</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link type="text/css" rel="stylesheet" href="assets/style.css" />
-  <link type="text/css" rel="stylesheet" href="assets/pilcrow.css" />
-  <link type="text/css" rel="stylesheet" href="assets/hljs-github.min.css"/>
-  <link rel="shortcut icon" href="assets/favicon.ico" type="image/x-icon">
-  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-110647385-1"></script>
-  <script type="text/javascript">
-    var LANGUAGE = 'pl';
-    
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'UA-110647385-1');
-  </script>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
-</head>
-<body>
-  <header>
-    <a class="logo" href="/">
-      <img class="parcel" src="assets/parcel.png" srcset="assets/parcel@2x.png 2x, assets/parcel@3x.png 3x" height="30">
-      <img class="type" src="assets/logo.svg" alt="Parcel">
-    </a>
-    <div class="links">
-      <input type="text" id="search-input" class="search-input" placeholder="Szukaj..." />
-      <form class="languages">
-        <select class="language-dropdown" onchange="location = this.options[this.selectedIndex].value;">
-          <option class="en" value="https://en.parceljs.org">English</option>
-          <option class="es" value="https://es.parceljs.org">Español</option>
-          <option class="fr" value="https://fr.parceljs.org">Français</option>
-          <option class="it" value="https://it.parceljs.org">Italiano</option>
-          <option class="ko" value="https://ko.parceljs.org">한국어</option>
-          <option class="pl" value="https://pl.parceljs.org" selected>Polskie</option>
-          <option class="pt" value="https://pt.parceljs.org">Português</option>
-          <option class="ru" value="https://ru.parceljs.org">Русский</option>
-          <option class="uk" value="https://uk.parceljs.org">Українська</option>
-          <option class="zh" value="https://zh.parceljs.org">简体中文</option>
-          <option class="zh-tw" value="https://zh-tw.parceljs.org">繁體中文</option>
-          
-        </select>
-      </form>
-      <a href="https://github.com/parcel-bundler/parcel" target="_blank">GitHub</a>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{{title}}</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link type="text/css" rel="stylesheet" href="assets/style.css" />
+    <link type="text/css" rel="stylesheet" href="assets/pilcrow.css" />
+    <link type="text/css" rel="stylesheet" href="assets/hljs-github.min.css" />
+    <link rel="shortcut icon" href="assets/favicon.ico" type="image/x-icon" />
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-110647385-1"></script>
+    <script type="text/javascript">
+      var LANGUAGE = 'pl'
+
+      window.dataLayer = window.dataLayer || []
+      function gtag() {
+        dataLayer.push(arguments)
+      }
+      gtag('js', new Date())
+      gtag('config', 'UA-110647385-1')
+    </script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
+  </head>
+  <body>
+    <header>
+      <a class="logo" href="/">
+        <img
+          class="parcel"
+          src="assets/parcel.png"
+          srcset="assets/parcel@2x.png 2x, assets/parcel@3x.png 3x"
+          height="30"
+        />
+        <img class="type" src="assets/logo.svg" alt="Parcel" />
+      </a>
+      <div class="links">
+        <input type="text" id="search-input" class="search-input" placeholder="Szukaj..." />
+        <form class="languages">
+          <select class="language-dropdown" onchange="location = this.options[this.selectedIndex].value;">
+            <option class="en" value="https://en.parceljs.org">English</option>
+            <option class="es" value="https://es.parceljs.org">Español</option>
+            <option class="fr" value="https://fr.parceljs.org">Français</option>
+            <option class="it" value="https://it.parceljs.org">Italiano</option>
+            <option class="ko" value="https://ko.parceljs.org">한국어</option>
+            <option class="pl" value="https://pl.parceljs.org" selected>Polskie</option>
+            <option class="pt" value="https://pt.parceljs.org">Português</option>
+            <option class="ru" value="https://ru.parceljs.org">Русский</option>
+            <option class="uk" value="https://uk.parceljs.org">Українська</option>
+            <option class="zh" value="https://zh.parceljs.org">简体中文</option>
+            <option class="zh-tw" value="https://zh-tw.parceljs.org">繁體中文</option>
+          </select>
+        </form>
+        <a href="https://github.com/parcel-bundler/parcel" target="_blank">GitHub</a>
+      </div>
+    </header>
+    <div class="content">
+      <nav>
+        <ul>
+          <li><a href="getting_started.html">🚀 Wprowadzenie</a></li>
+          <li><a href="assets.html">📦 Zasoby</a></li>
+          <li><a href="transforms.html">🐠 Transformacje</a></li>
+          <li><a href="code_splitting.html">✂️ Dzielenie Kodu</a></li>
+          <li><a href="hmr.html">🔥 Hot Module Replacement</a></li>
+          <li><a href="production.html">✨ Produkcja</a></li>
+          <li><a href="recipes.html">🍰 Przepisy</a></li>
+        </ul>
+        <h3>Advanced</h3>
+        <ul>
+          <li><a href="how_it_works.html">🛠 Jak To Działa</a></li>
+          <li><a href="asset_types.html">📝 Typy Zasobów</a></li>
+          <li><a href="packagers.html">📦 Programy Pakujące</a></li>
+          <li><a href="plugins.html">🔌 Wtyczki</a></li>
+        </ul>
+      </nav>
+      <main>
+        {{~> content}}
+
+        <h2>Help us improve the docs</h2>
+        <p>
+          If something is missing or not entirely clear, please
+          <a href="https://github.com/parcel-bundler/website/issues">file an issue on the website repository</a> or
+          <a href="https://github.com/parcel-bundler/website/edit/master/src/i18n/{{language}}/docs/{{relative}}"
+            >edit this page</a
+          >.
+        </p>
+      </main>
     </div>
-  </header>
-  <div class="content">
-    <nav>
-      <ul>
-        <li><a href="getting_started.html">🚀 Wprowadzenie</a></li>
-        <li><a href="assets.html">📦 Zasoby</a></li>
-        <li><a href="transforms.html">🐠 Transformacje</a></li>
-        <li><a href="code_splitting.html">✂️ Dzielenie Kodu</a></li>
-        <li><a href="hmr.html">🔥 Hot Module Replacement</a></li>
-        <li><a href="production.html">✨ Produkcja</a></li>
-        <li><a href="recipes.html">🍰 Przepisy</a></li>
-      </ul>
-      <h3>Advanced</h3>
-      <ul>
-        <li><a href="how_it_works.html">🛠 Jak To Działa</a></li>
-        <li><a href="asset_types.html">📝 Typy Zasobów</a></li>
-        <li><a href="packagers.html">📦 Programy Pakujące</a></li>
-        <li><a href="plugins.html">🔌 Wtyczki</a></li>
-      </ul>
-    </nav>
-    <main>
-      {{~> content}}
+    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
+    <script type="text/javascript">
+      ;(function() {
+        var pathname = window.location.pathname.substr(1)
+        var activeLink = document.querySelector('a[href="' + pathname + '"]')
 
-      <h2>Help us improve the docs</h2>
-      <p>If something is missing or not entirely clear, please 
-          <a href="https://github.com/parcel-bundler/website/issues">file an issue on the website repository</a> 
-          or <a href="https://github.com/parcel-bundler/website/edit/master/src/i18n/{{language}}/docs/{{relative}}">edit this page</a>.</p>
-    </main>
-  </div>
-  <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
-  <script type="text/javascript">
-    (function () {
-      var pathname = window.location.pathname.substr(1);
-      var activeLink = document.querySelector('a[href="' + pathname + '"]');
+        activeLink.classList.add('selected')
+        if (activeLink.scrollIntoView) activeLink.scrollIntoView()
 
-      activeLink.classList.add('selected');
-
-      docsearch({
-        apiKey: '8b6be780425a72d1a1683abea2636778',
-        indexName: 'parceljs',
-        inputSelector: '#search-input',
-        algoliaOptions: {
-          'facetFilters': [
-            `lang:${LANGUAGE}`
-          ]
-        }
-      });
-    })();
-  </script>
-</body>
+        docsearch({
+          apiKey: '8b6be780425a72d1a1683abea2636778',
+          indexName: 'parceljs',
+          inputSelector: '#search-input',
+          algoliaOptions: {
+            facetFilters: [`lang:${LANGUAGE}`]
+          }
+        })
+      })()
+    </script>
+  </body>
 </html>

--- a/src/i18n/ru/layout/page.html
+++ b/src/i18n/ru/layout/page.html
@@ -1,99 +1,108 @@
 <!DOCTYPE html>
 <html lang="ru">
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>{{title}}</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link type="text/css" rel="stylesheet" href="assets/style.css" />
-  <link type="text/css" rel="stylesheet" href="assets/pilcrow.css" />
-  <link type="text/css" rel="stylesheet" href="assets/hljs-github.min.css"/>
-  <link rel="shortcut icon" href="assets/favicon.ico" type="image/x-icon">
-  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-110647385-1"></script>
-  <script type="text/javascript">
-    var LANGUAGE = 'ru';
-    
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'UA-110647385-1');
-  </script>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
-</head>
-<body>
-  <header>
-    <a class="logo" href="/">
-      <img class="parcel" src="assets/parcel.png" srcset="assets/parcel@2x.png 2x, assets/parcel@3x.png 3x" height="30">
-      <img class="type" src="assets/logo.svg" alt="Parcel">
-    </a>
-    <div class="links">
-      <input type="text" id="search-input" class="search-input" placeholder="поиск..." />
-      <form class="languages">
-        <select class="language-dropdown" onchange="location = this.options[this.selectedIndex].value;">
-          <option class="en" value="https://en.parceljs.org">English</option>
-          <option class="es" value="https://es.parceljs.org">Español</option>
-          <option class="fr" value="https://fr.parceljs.org">Français</option>
-          <option class="it" value="https://it.parceljs.org">Italiano</option>
-          <option class="ko" value="https://ko.parceljs.org">한국어</option>
-          <option class="pl" value="https://pl.parceljs.org">Polskie</option>
-          <option class="pt" value="https://pt.parceljs.org">Português</option>
-          <option class="ru" value="https://ru.parceljs.org" selected>Русский</option>
-          <option class="uk" value="https://uk.parceljs.org">Українська</option>
-          <option class="zh" value="https://zh.parceljs.org">简体中文</option>
-          <option class="zh-tw" value="https://zh-tw.parceljs.org">繁體中文</option>
-          
-        </select>
-      </form>
-      <a href="https://github.com/parcel-bundler/parcel" target="_blank">GitHub</a>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{{title}}</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link type="text/css" rel="stylesheet" href="assets/style.css" />
+    <link type="text/css" rel="stylesheet" href="assets/pilcrow.css" />
+    <link type="text/css" rel="stylesheet" href="assets/hljs-github.min.css" />
+    <link rel="shortcut icon" href="assets/favicon.ico" type="image/x-icon" />
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-110647385-1"></script>
+    <script type="text/javascript">
+      var LANGUAGE = 'ru'
+
+      window.dataLayer = window.dataLayer || []
+      function gtag() {
+        dataLayer.push(arguments)
+      }
+      gtag('js', new Date())
+      gtag('config', 'UA-110647385-1')
+    </script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
+  </head>
+  <body>
+    <header>
+      <a class="logo" href="/">
+        <img
+          class="parcel"
+          src="assets/parcel.png"
+          srcset="assets/parcel@2x.png 2x, assets/parcel@3x.png 3x"
+          height="30"
+        />
+        <img class="type" src="assets/logo.svg" alt="Parcel" />
+      </a>
+      <div class="links">
+        <input type="text" id="search-input" class="search-input" placeholder="поиск..." />
+        <form class="languages">
+          <select class="language-dropdown" onchange="location = this.options[this.selectedIndex].value;">
+            <option class="en" value="https://en.parceljs.org">English</option>
+            <option class="es" value="https://es.parceljs.org">Español</option>
+            <option class="fr" value="https://fr.parceljs.org">Français</option>
+            <option class="it" value="https://it.parceljs.org">Italiano</option>
+            <option class="ko" value="https://ko.parceljs.org">한국어</option>
+            <option class="pl" value="https://pl.parceljs.org">Polskie</option>
+            <option class="pt" value="https://pt.parceljs.org">Português</option>
+            <option class="ru" value="https://ru.parceljs.org" selected>Русский</option>
+            <option class="uk" value="https://uk.parceljs.org">Українська</option>
+            <option class="zh" value="https://zh.parceljs.org">简体中文</option>
+            <option class="zh-tw" value="https://zh-tw.parceljs.org">繁體中文</option>
+          </select>
+        </form>
+        <a href="https://github.com/parcel-bundler/parcel" target="_blank">GitHub</a>
+      </div>
+    </header>
+    <div class="content">
+      <nav>
+        <ul>
+          <li><a href="getting_started.html">🚀 Начало работы</a></li>
+          <li><a href="assets.html">📦 Ресурсы</a></li>
+          <li><a href="transforms.html">🐠 Трансформации</a></li>
+          <li><a href="code_splitting.html">✂️ Разделение кода</a></li>
+          <li><a href="hmr.html">🔥 Горячая замена модуля</a></li>
+          <li><a href="production.html">✨ Работа в продакшене</a></li>
+          <li><a href="recipes.html">🍰 Рецепты</a></li>
+        </ul>
+        <h3>Advanced</h3>
+        <ul>
+          <li><a href="how_it_works.html">🛠 Как это работает?</a></li>
+          <li><a href="asset_types.html">📝 Типы ресурсов</a></li>
+          <li><a href="packagers.html">📦 Упаковщики</a></li>
+          <li><a href="plugins.html">🔌 Плагины</a></li>
+        </ul>
+      </nav>
+      <main>
+        {{~> content}}
+
+        <h2>Help us improve the docs</h2>
+        <p>
+          If something is missing or not entirely clear, please
+          <a href="https://github.com/parcel-bundler/website/issues">file an issue on the website repository</a> or
+          <a href="https://github.com/parcel-bundler/website/edit/master/src/i18n/{{language}}/docs/{{relative}}"
+            >edit this page</a
+          >.
+        </p>
+      </main>
     </div>
-  </header>
-  <div class="content">
-    <nav>
-      <ul>
-        <li><a href="getting_started.html">🚀 Начало работы</a></li>
-        <li><a href="assets.html">📦 Ресурсы</a></li>
-        <li><a href="transforms.html">🐠 Трансформации</a></li>
-        <li><a href="code_splitting.html">✂️ Разделение кода</a></li>
-        <li><a href="hmr.html">🔥 Горячая замена модуля</a></li>
-        <li><a href="production.html">✨ Работа в продакшене</a></li>
-        <li><a href="recipes.html">🍰 Рецепты</a></li>
-      </ul>
-      <h3>Advanced</h3>
-      <ul>
-        <li><a href="how_it_works.html">🛠 Как это работает?</a></li>
-        <li><a href="asset_types.html">📝 Типы ресурсов</a></li>
-        <li><a href="packagers.html">📦 Упаковщики</a></li>
-        <li><a href="plugins.html">🔌 Плагины</a></li>
-      </ul>
-    </nav>
-    <main>
-      {{~> content}}
+    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
+    <script type="text/javascript">
+      ;(function() {
+        var pathname = window.location.pathname.substr(1)
+        var activeLink = document.querySelector('a[href="' + pathname + '"]')
 
-      <h2>Help us improve the docs</h2>
-      <p>If something is missing or not entirely clear, please 
-          <a href="https://github.com/parcel-bundler/website/issues">file an issue on the website repository</a> 
-          or <a href="https://github.com/parcel-bundler/website/edit/master/src/i18n/{{language}}/docs/{{relative}}">edit this page</a>.</p>
-    </main>
-  </div>
-  <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
-  <script type="text/javascript">
-    (function () {
-      var pathname = window.location.pathname.substr(1);
-      var activeLink = document.querySelector('a[href="' + pathname + '"]');
+        activeLink.classList.add('selected')
+        if (activeLink.scrollIntoView) activeLink.scrollIntoView()
 
-      activeLink.classList.add('selected');
-
-      docsearch({
-        apiKey: '8b6be780425a72d1a1683abea2636778',
-        indexName: 'parceljs',
-        inputSelector: '#search-input',
-        algoliaOptions: {
-          'facetFilters': [
-            `lang:${LANGUAGE}`
-          ]
-        }
-      });
-    })();
-  </script>
-</body>
+        docsearch({
+          apiKey: '8b6be780425a72d1a1683abea2636778',
+          indexName: 'parceljs',
+          inputSelector: '#search-input',
+          algoliaOptions: {
+            facetFilters: [`lang:${LANGUAGE}`]
+          }
+        })
+      })()
+    </script>
+  </body>
 </html>

--- a/src/i18n/uk/layout/page.html
+++ b/src/i18n/uk/layout/page.html
@@ -1,102 +1,112 @@
 <!DOCTYPE html>
 <html lang="uk">
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>{{title}}</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link type="text/css" rel="stylesheet" href="assets/style.css" />
-  <link type="text/css" rel="stylesheet" href="assets/pilcrow.css" />
-  <link type="text/css" rel="stylesheet" href="assets/hljs-github.min.css"/>
-  <link rel="shortcut icon" href="assets/favicon.ico" type="image/x-icon">
-  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-110647385-1"></script>
-  <script type="text/javascript">
-    var LANGUAGE = 'uk';
-    
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'UA-110647385-1');
-  </script>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
-</head>
-<body>
-  <header>
-    <a class="logo" href="/">
-      <img class="parcel" src="assets/parcel.png" srcset="assets/parcel@2x.png 2x, assets/parcel@3x.png 3x" height="30">
-      <img class="type" src="assets/logo.svg" alt="Parcel">
-    </a>
-    <div class="links">
-      <input type="text" id="search-input" class="search-input" placeholder="пошук..." />
-      <form class="languages">
-        <select class="language-dropdown" onchange="location = this.options[this.selectedIndex].value;">
-          <option class="en" value="https://en.parceljs.org">English</option>
-          <option class="es" value="https://es.parceljs.org">Español</option>
-          <option class="fr" value="https://fr.parceljs.org">Français</option>
-          <option class="it" value="https://it.parceljs.org">Italiano</option>
-          <option class="ko" value="https://ko.parceljs.org">한국어</option>
-          <option class="pl" value="https://pl.parceljs.org">Polskie</option>
-          <option class="pt" value="https://pt.parceljs.org">Português</option>
-          <option class="ru" value="https://ru.parceljs.org">Русский</option>
-          <option class="uk" value="https://uk.parceljs.org" selected>Українська</option>
-          <option class="zh" value="https://zh.parceljs.org">简体中文</option>
-          <option class="zh-tw" value="https://zh-tw.parceljs.org">繁體中文</option>
-        </select>
-      </form>
-      <a href="https://github.com/parcel-bundler/parcel" target="_blank">GitHub</a>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{{title}}</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link type="text/css" rel="stylesheet" href="assets/style.css" />
+    <link type="text/css" rel="stylesheet" href="assets/pilcrow.css" />
+    <link type="text/css" rel="stylesheet" href="assets/hljs-github.min.css" />
+    <link rel="shortcut icon" href="assets/favicon.ico" type="image/x-icon" />
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-110647385-1"></script>
+    <script type="text/javascript">
+      var LANGUAGE = 'uk'
+
+      window.dataLayer = window.dataLayer || []
+      function gtag() {
+        dataLayer.push(arguments)
+      }
+      gtag('js', new Date())
+      gtag('config', 'UA-110647385-1')
+    </script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
+  </head>
+  <body>
+    <header>
+      <a class="logo" href="/">
+        <img
+          class="parcel"
+          src="assets/parcel.png"
+          srcset="assets/parcel@2x.png 2x, assets/parcel@3x.png 3x"
+          height="30"
+        />
+        <img class="type" src="assets/logo.svg" alt="Parcel" />
+      </a>
+      <div class="links">
+        <input type="text" id="search-input" class="search-input" placeholder="пошук..." />
+        <form class="languages">
+          <select class="language-dropdown" onchange="location = this.options[this.selectedIndex].value;">
+            <option class="en" value="https://en.parceljs.org">English</option>
+            <option class="es" value="https://es.parceljs.org">Español</option>
+            <option class="fr" value="https://fr.parceljs.org">Français</option>
+            <option class="it" value="https://it.parceljs.org">Italiano</option>
+            <option class="ko" value="https://ko.parceljs.org">한국어</option>
+            <option class="pl" value="https://pl.parceljs.org">Polskie</option>
+            <option class="pt" value="https://pt.parceljs.org">Português</option>
+            <option class="ru" value="https://ru.parceljs.org">Русский</option>
+            <option class="uk" value="https://uk.parceljs.org" selected>Українська</option>
+            <option class="zh" value="https://zh.parceljs.org">简体中文</option>
+            <option class="zh-tw" value="https://zh-tw.parceljs.org">繁體中文</option>
+          </select>
+        </form>
+        <a href="https://github.com/parcel-bundler/parcel" target="_blank">GitHub</a>
+      </div>
+    </header>
+    <div class="content">
+      <nav>
+        <ul>
+          <li><a href="getting_started.html">🚀 Початок роботи</a></li>
+          <li><a href="assets.html">📦 Ресурси</a></li>
+          <li><a href="module_resolution.html">📔 Дозволи модулів</a></li>
+          <li><a href="transforms.html">🐠 Трансформації</a></li>
+          <li><a href="code_splitting.html">✂️ Розділення коду</a></li>
+          <li><a href="env.html">🌳 Змінні середовища</a></li>
+          <li><a href="hmr.html">🔥 Гаряча заміна модуля</a></li>
+          <li><a href="production.html">✨ Робота в продакшені</a></li>
+          <li><a href="recipes.html">🍰 Рецепти</a></li>
+          <li><a href="cli.html">🖥 CLI</a></li>
+        </ul>
+        <h3>Advanced</h3>
+        <ul>
+          <li><a href="how_it_works.html">🛠 Як це працює?</a></li>
+          <li><a href="asset_types.html">📝 Типи ресурсів</a></li>
+          <li><a href="api.html">📚 API</a></li>
+          <li><a href="packagers.html">📦 Пакувальники</a></li>
+          <li><a href="plugins.html">🔌 Плаґіни</a></li>
+        </ul>
+      </nav>
+      <main>
+        {{~> content}}
+
+        <h2>Help us improve the docs</h2>
+        <p>
+          If something is missing or not entirely clear, please
+          <a href="https://github.com/parcel-bundler/website/issues">file an issue on the website repository</a> or
+          <a href="https://github.com/parcel-bundler/website/edit/master/src/i18n/{{language}}/docs/{{relative}}"
+            >edit this page</a
+          >.
+        </p>
+      </main>
     </div>
-  </header>
-  <div class="content">
-    <nav>
-      <ul>
-        <li><a href="getting_started.html">🚀 Початок роботи</a></li>
-        <li><a href="assets.html">📦 Ресурси</a></li>
-        <li><a href="module_resolution.html">📔 Дозволи модулів</a></li>
-        <li><a href="transforms.html">🐠 Трансформації</a></li>
-        <li><a href="code_splitting.html">✂️ Розділення коду</a></li>
-        <li><a href="env.html">🌳 Змінні середовища</a></li>
-        <li><a href="hmr.html">🔥 Гаряча заміна модуля</a></li>
-        <li><a href="production.html">✨ Робота в продакшені</a></li>
-        <li><a href="recipes.html">🍰 Рецепти</a></li>
-        <li><a href="cli.html">🖥 CLI</a></li>
-      </ul>
-      <h3>Advanced</h3>
-      <ul>
-        <li><a href="how_it_works.html">🛠 Як це працює?</a></li>
-        <li><a href="asset_types.html">📝 Типи ресурсів</a></li>
-        <li><a href="api.html">📚 API</a></li>
-        <li><a href="packagers.html">📦 Пакувальники</a></li>
-        <li><a href="plugins.html">🔌 Плаґіни</a></li>
-      </ul>
-    </nav>
-    <main>
-      {{~> content}}
+    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
+    <script type="text/javascript">
+      ;(function() {
+        var pathname = window.location.pathname.substr(1)
+        var activeLink = document.querySelector('a[href="' + pathname + '"]')
 
-      <h2>Help us improve the docs</h2>
-      <p>If something is missing or not entirely clear, please 
-          <a href="https://github.com/parcel-bundler/website/issues">file an issue on the website repository</a> 
-          or <a href="https://github.com/parcel-bundler/website/edit/master/src/i18n/{{language}}/docs/{{relative}}">edit this page</a>.</p>
-    </main>
-  </div>
-  <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
-  <script type="text/javascript">
-    (function () {
-      var pathname = window.location.pathname.substr(1);
-      var activeLink = document.querySelector('a[href="' + pathname + '"]');
+        activeLink.classList.add('selected')
+        if (activeLink.scrollIntoView) activeLink.scrollIntoView()
 
-      activeLink.classList.add('selected');
-
-      docsearch({
-        apiKey: '8b6be780425a72d1a1683abea2636778',
-        indexName: 'parceljs',
-        inputSelector: '#search-input',
-        algoliaOptions: {
-          'facetFilters': [
-            `lang:${LANGUAGE}`
-          ]
-        }
-      });
-    })();
-  </script>
-</body>
+        docsearch({
+          apiKey: '8b6be780425a72d1a1683abea2636778',
+          indexName: 'parceljs',
+          inputSelector: '#search-input',
+          algoliaOptions: {
+            facetFilters: [`lang:${LANGUAGE}`]
+          }
+        })
+      })()
+    </script>
+  </body>
 </html>

--- a/src/i18n/zh-tw/layout/page.html
+++ b/src/i18n/zh-tw/layout/page.html
@@ -1,165 +1,173 @@
 <!DOCTYPE html>
 <html lang="zh-tw">
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>{{title}}</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link type="text/css" rel="stylesheet" href="assets/style.css" />
-  <link type="text/css" rel="stylesheet" href="assets/pilcrow.css" />
-  <link type="text/css" rel="stylesheet" href="assets/hljs-github.min.css"/>
-  <link rel="shortcut icon" href="assets/favicon.ico" type="image/x-icon">
-  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-110647385-1"></script>
-  <script>
-    var LANGUAGE = 'zh-tw';
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'UA-110647385-1');
-  </script>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
-</head>
-<body>
-  <header>
-    <a class="logo" href="/">
-      <img class="parcel" src="assets/parcel.png" srcset="assets/parcel@2x.png 2x, assets/parcel@3x.png 3x" height="30">
-      <img class="type" src="assets/logo.svg" alt="Parcel">
-    </a>
-    <div class="links">
-      <input type="text" id="search-input" class="search-input" placeholder="搜尋..." />
-      <form class="languages">
-        <select class="language-dropdown" onchange="location = this.options[this.selectedIndex].value;">
-          <option class="en" value="https://en.parceljs.org">English</option>
-          <option class="es" value="https://es.parceljs.org">Español</option>
-          <option class="fr" value="https://fr.parceljs.org">Français</option>
-          <option class="it" value="https://it.parceljs.org">Italiano</option>
-          <option class="ko" value="https://ko.parceljs.org">한국어</option>
-          <option class="pl" value="https://pl.parceljs.org">Polskie</option>
-          <option class="pt" value="https://pt.parceljs.org">Português</option>
-          <option class="ru" value="https://ru.parceljs.org">Русский</option>
-          <option class="zh" value="https://zh.parceljs.org">简体中文</option>
-          <option class="zh-tw" value="https://zh-tw.parceljs.org" selected>繁體中文</option>
-        </select>
-      </form>
-      <a href="https://github.com/parcel-bundler/parcel" target="_blank">GitHub</a>
-      <a href="https://cottonbureau.com/products/parcel-t-shirt" target="_blank">👕 商店</a>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{{title}}</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link type="text/css" rel="stylesheet" href="assets/style.css" />
+    <link type="text/css" rel="stylesheet" href="assets/pilcrow.css" />
+    <link type="text/css" rel="stylesheet" href="assets/hljs-github.min.css" />
+    <link rel="shortcut icon" href="assets/favicon.ico" type="image/x-icon" />
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-110647385-1"></script>
+    <script>
+      var LANGUAGE = 'zh-tw'
+      window.dataLayer = window.dataLayer || []
+      function gtag() {
+        dataLayer.push(arguments)
+      }
+      gtag('js', new Date())
+      gtag('config', 'UA-110647385-1')
+    </script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
+  </head>
+  <body>
+    <header>
+      <a class="logo" href="/">
+        <img
+          class="parcel"
+          src="assets/parcel.png"
+          srcset="assets/parcel@2x.png 2x, assets/parcel@3x.png 3x"
+          height="30"
+        />
+        <img class="type" src="assets/logo.svg" alt="Parcel" />
+      </a>
+      <div class="links">
+        <input type="text" id="search-input" class="search-input" placeholder="搜尋..." />
+        <form class="languages">
+          <select class="language-dropdown" onchange="location = this.options[this.selectedIndex].value;">
+            <option class="en" value="https://en.parceljs.org">English</option>
+            <option class="es" value="https://es.parceljs.org">Español</option>
+            <option class="fr" value="https://fr.parceljs.org">Français</option>
+            <option class="it" value="https://it.parceljs.org">Italiano</option>
+            <option class="ko" value="https://ko.parceljs.org">한국어</option>
+            <option class="pl" value="https://pl.parceljs.org">Polskie</option>
+            <option class="pt" value="https://pt.parceljs.org">Português</option>
+            <option class="ru" value="https://ru.parceljs.org">Русский</option>
+            <option class="zh" value="https://zh.parceljs.org">简体中文</option>
+            <option class="zh-tw" value="https://zh-tw.parceljs.org" selected>繁體中文</option>
+          </select>
+        </form>
+        <a href="https://github.com/parcel-bundler/parcel" target="_blank">GitHub</a>
+        <a href="https://cottonbureau.com/products/parcel-t-shirt" target="_blank">👕 商店</a>
+      </div>
+    </header>
+    <div class="content">
+      <nav>
+        <h3>開始使用</h3>
+        <ul>
+          <li><a href="getting_started.html">🚀 開始使用</a></li>
+          <li><a href="assets.html">📦 資源</a></li>
+          <li><a href="transforms.html">🐠 轉換</a></li>
+        </ul>
+        <h3>特色</h3>
+        <ul>
+          <li><a href="code_splitting.html">✂️ 程式碼分離</a></li>
+          <li><a href="hmr.html">🔥 模組熱替換</a></li>
+          <li><a href="production.html">✨ 正式環境</a></li>
+          <li><a href="cli.html">🖥 CLI</a></li>
+          <li><a href="recipes.html">🍰 秘方</a></li>
+          <li><a href="env.html">🌳 環境變數</a></li>
+          <li><a href="module_resolution.html">📔 模組解析</a></li>
+        </ul>
+        <h3>📦 資源類型</h3>
+        <ul>
+          <li>
+            <a href="javascript.html"><img src="assets/icon-javascript.svg" />Javascript</a>
+          </li>
+          <li>
+            <a href="reasonML.html"><img src="assets/icon-reason-ml.svg" />ReasonML</a>
+          </li>
+          <li>
+            <a href="css.html"><img src="assets/icon-css.svg" />CSS</a>
+          </li>
+          <li>
+            <a href="scss.html"><img src="assets/icon-sass.svg" />SCSS</a>
+          </li>
+          <li>
+            <a href="less.html"><img src="assets/icon-less.svg" />LESS</a>
+          </li>
+          <li>
+            <a href="stylus.html"><img src="assets/icon-stylus.svg" />Stylus</a>
+          </li>
+          <li>
+            <a href="html.html"><img src="assets/icon-html5.svg" />HTML</a>
+          </li>
+          <li>
+            <a href="typeScript.html"><img src="assets/icon-typescript.svg" />TypeScript</a>
+          </li>
+          <li>
+            <a href="coffeeScript.html"><img src="assets/icon-coffeescript.svg" />CoffeeScript</a>
+          </li>
+          <li>
+            <a href="vue.html"><img src="assets/icon-vuejs.svg" />Vue</a>
+          </li>
+          <li>
+            <a href="json.html"><img src="assets/icon-json.svg" />JSON</a>
+          </li>
+          <li>
+            <a href="graphQL.html"><img src="assets/icon-graphql.svg" />GraphQL</a>
+          </li>
+          <li>
+            <a href="rust.html"><img src="assets/icon-rust.svg" />Rust</a>
+          </li>
+          <li>
+            <a href="webAssembly.html"><img src="assets/icon-webassembly.svg" />WebAssembly</a>
+          </li>
+          <li>
+            <a href="yaml.html"><img src="assets/icon-yaml.svg" />YAML</a>
+          </li>
+          <li>
+            <a href="toml.html"><img src="assets/icon-toml.svg" />TOML</a>
+          </li>
+          <li>
+            <a href="openGL.html"><img src="assets/icon-openGL.svg" />OpenGL</a>
+          </li>
+          <li>
+            <a href="pug.html"><img src="assets/icon-pug.svg" />Pug</a>
+          </li>
+          <li><a href="webManifest.html">WebManifest</a></li>
+        </ul>
+        <h3>進階</h3>
+        <ul>
+          <li><a href="how_it_works.html">🛠 運作原理</a></li>
+          <li><a href="asset_types.html">📝 資源類型</a></li>
+          <li><a href="plugins.html">🔌 外掛</a></li>
+          <li><a href="packagers.html">📦 Packagers</a></li>
+          <li><a href="api.html">📚 API</a></li>
+        </ul>
+      </nav>
+      <main>
+        {{~> content}}
+
+        <h2>協助我們讓本文件更加完善</h2>
+        <p>
+          若有什麼內容遺漏了或是敘述不清楚的地方，請在本站的
+          <a href="https://github.com/parcel-bundler/website/issues">repository</a> 中開啟一個 issue 或者<a
+            href="https://github.com/parcel-bundler/website/edit/master/src/i18n/{{language}}/docs/{{relative}}"
+            >編輯此頁面</a
+          >。
+        </p>
+      </main>
     </div>
-  </header>
-  <div class="content">
-    <nav>
-      <h3>開始使用</h3>
-      <ul>
-        <li><a href="getting_started.html">🚀 開始使用</a></li>
-        <li><a href="assets.html">📦 資源</a></li>
-        <li><a href="transforms.html">🐠 轉換</a></li>
-      </ul>
-      <h3>特色</h3>
-      <ul>
-        <li><a href="code_splitting.html">✂️ 程式碼分離</a></li>
-        <li><a href="hmr.html">🔥 模組熱替換</a></li>
-        <li><a href="production.html">✨ 正式環境</a></li>
-        <li><a href="cli.html">🖥 CLI</a></li>
-        <li><a href="recipes.html">🍰 秘方</a></li>
-        <li><a href="env.html">🌳 環境變數</a></li>
-        <li><a href="module_resolution.html">📔 模組解析</a></li>
-      </ul>
-      <h3>📦 資源類型</h3>
-      <ul>
-        <li>
-          <a href="javascript.html"><img src="assets/icon-javascript.svg">Javascript</a>
-        </li>
-        <li>
-          <a href="reasonML.html"><img src="assets/icon-reason-ml.svg">ReasonML</a>
-        </li>
-        <li>
-          <a href="css.html"><img src="assets/icon-css.svg">CSS</a>
-        </li>
-        <li>
-          <a href="scss.html"><img src="assets/icon-sass.svg">SCSS</a>
-        </li>
-        <li>
-          <a href="less.html"><img src="assets/icon-less.svg">LESS</a>
-        </li>
-        <li>
-          <a href="stylus.html"><img src="assets/icon-stylus.svg">Stylus</a>
-        </li>
-        <li>
-          <a href="html.html"><img src="assets/icon-html5.svg">HTML</a>
-        </li>
-        <li>
-          <a href="typeScript.html"><img src="assets/icon-typescript.svg">TypeScript</a>
-        </li>
-        <li>
-          <a href="coffeeScript.html"><img src="assets/icon-coffeescript.svg">CoffeeScript</a>
-        </li>
-        <li>
-          <a href="vue.html"><img src="assets/icon-vuejs.svg">Vue</a>
-        </li>
-        <li>
-          <a href="json.html"><img src="assets/icon-json.svg">JSON</a>
-        </li>
-        <li>
-          <a href="graphQL.html"><img src="assets/icon-graphql.svg">GraphQL</a>
-        </li>
-        <li>
-          <a href="rust.html"><img src="assets/icon-rust.svg">Rust</a>
-        </li>
-        <li>
-          <a href="webAssembly.html"><img src="assets/icon-webassembly.svg">WebAssembly</a>
-        </li>
-        <li>
-          <a href="yaml.html"><img src="assets/icon-yaml.svg">YAML</a>
-        </li>
-        <li>
-          <a href="toml.html"><img src="assets/icon-toml.svg">TOML</a>
-        </li>
-        <li>
-          <a href="openGL.html"><img src="assets/icon-openGL.svg">OpenGL</a>
-        </li>
-        <li>
-          <a href="pug.html"><img src="assets/icon-pug.svg">Pug</a>
-        </li>
-        <li>
-          <a href="webManifest.html">WebManifest</a>
-        </li>
-      </ul>
-      <h3>進階</h3>
-      <ul>
-        <li><a href="how_it_works.html">🛠 運作原理</a></li>
-        <li><a href="asset_types.html">📝 資源類型</a></li>
-        <li><a href="plugins.html">🔌 外掛</a></li>
-        <li><a href="packagers.html">📦 Packagers</a></li>
-        <li><a href="api.html">📚 API</a></li>
-      </ul>
-    </nav>
-    <main>
-      {{~> content}}
+    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
+    <script type="text/javascript">
+      ;(function() {
+        var pathname = window.location.pathname.substr(1)
+        var activeLink = document.querySelector('a[href="' + pathname + '"]')
 
-      <h2>協助我們讓本文件更加完善</h2>
-      <p>若有什麼內容遺漏了或是敘述不清楚的地方，請在本站的
-        <a href="https://github.com/parcel-bundler/website/issues">repository</a> 中開啟一個 issue
-        或者<a href="https://github.com/parcel-bundler/website/edit/master/src/i18n/{{language}}/docs/{{relative}}">編輯此頁面</a>。</p>
-    </main>
-  </div>
-  <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
-  <script type="text/javascript">
-    (function () {
-      var pathname = window.location.pathname.substr(1);
-      var activeLink = document.querySelector('a[href="' + pathname + '"]');
+        activeLink.classList.add('selected')
+        if (activeLink.scrollIntoView) activeLink.scrollIntoView()
 
-      activeLink.classList.add('selected');
-
-      docsearch({
-        apiKey: '8b6be780425a72d1a1683abea2636778',
-        indexName: 'parceljs',
-        inputSelector: '#search-input',
-        algoliaOptions: {
-          'facetFilters': [
-            `lang:${LANGUAGE}`
-          ]
-        }
-      });
-    })();
-  </script>
-</body>
+        docsearch({
+          apiKey: '8b6be780425a72d1a1683abea2636778',
+          indexName: 'parceljs',
+          inputSelector: '#search-input',
+          algoliaOptions: {
+            facetFilters: [`lang:${LANGUAGE}`]
+          }
+        })
+      })()
+    </script>
+  </body>
 </html>

--- a/src/i18n/zh/layout/page.html
+++ b/src/i18n/zh/layout/page.html
@@ -1,100 +1,110 @@
 <!DOCTYPE html>
 <html lang="zh">
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>{{title}}</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link type="text/css" rel="stylesheet" href="assets/style.css" />
-  <link type="text/css" rel="stylesheet" href="assets/pilcrow.css" />
-  <link type="text/css" rel="stylesheet" href="assets/hljs-github.min.css"/>
-  <link rel="shortcut icon" href="assets/favicon.ico" type="image/x-icon">
-  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-110647385-1"></script>
-  <script type="text/javascript">
-    var LANGUAGE = 'zh';
-    
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'UA-110647385-1');
-  </script>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
-</head>
-<body>
-  <header>
-    <a class="logo" href="/">
-      <img class="parcel" src="assets/parcel.png" srcset="assets/parcel@2x.png 2x, assets/parcel@3x.png 3x" height="30">
-      <img class="type" src="assets/logo.svg" alt="Parcel">
-    </a>
-    <div class="links">
-      <input type="text" id="search-input" class="search-input" placeholder="搜索..." />
-      <form class="languages">
-        <select class="language-dropdown" onchange="location = this.options[this.selectedIndex].value;">
-          <option class="en" value="https://en.parceljs.org">English</option>
-          <option class="es" value="https://es.parceljs.org">Español</option>
-          <option class="fr" value="https://fr.parceljs.org">Français</option>
-          <option class="it" value="https://it.parceljs.org">Italiano</option>
-          <option class="ko" value="https://ko.parceljs.org">한국어</option>
-          <option class="pl" value="https://pl.parceljs.org">Polskie</option>
-          <option class="pt" value="https://pt.parceljs.org">Português</option>
-          <option class="ru" value="https://ru.parceljs.org">Русский</option>
-          <option class="uk" value="https://uk.parceljs.org">Українська</option>
-          <option class="zh" value="https://zh.parceljs.org" selected>简体中文</option>
-          <option class="zh-tw" value="https://zh-tw.parceljs.org">繁體中文</option>
-        </select>
-      </form>
-      <a href="https://github.com/parcel-bundler/parcel" target="_blank">GitHub</a>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{{title}}</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link type="text/css" rel="stylesheet" href="assets/style.css" />
+    <link type="text/css" rel="stylesheet" href="assets/pilcrow.css" />
+    <link type="text/css" rel="stylesheet" href="assets/hljs-github.min.css" />
+    <link rel="shortcut icon" href="assets/favicon.ico" type="image/x-icon" />
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-110647385-1"></script>
+    <script type="text/javascript">
+      var LANGUAGE = 'zh'
+
+      window.dataLayer = window.dataLayer || []
+      function gtag() {
+        dataLayer.push(arguments)
+      }
+      gtag('js', new Date())
+      gtag('config', 'UA-110647385-1')
+    </script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
+  </head>
+  <body>
+    <header>
+      <a class="logo" href="/">
+        <img
+          class="parcel"
+          src="assets/parcel.png"
+          srcset="assets/parcel@2x.png 2x, assets/parcel@3x.png 3x"
+          height="30"
+        />
+        <img class="type" src="assets/logo.svg" alt="Parcel" />
+      </a>
+      <div class="links">
+        <input type="text" id="search-input" class="search-input" placeholder="搜索..." />
+        <form class="languages">
+          <select class="language-dropdown" onchange="location = this.options[this.selectedIndex].value;">
+            <option class="en" value="https://en.parceljs.org">English</option>
+            <option class="es" value="https://es.parceljs.org">Español</option>
+            <option class="fr" value="https://fr.parceljs.org">Français</option>
+            <option class="it" value="https://it.parceljs.org">Italiano</option>
+            <option class="ko" value="https://ko.parceljs.org">한국어</option>
+            <option class="pl" value="https://pl.parceljs.org">Polskie</option>
+            <option class="pt" value="https://pt.parceljs.org">Português</option>
+            <option class="ru" value="https://ru.parceljs.org">Русский</option>
+            <option class="uk" value="https://uk.parceljs.org">Українська</option>
+            <option class="zh" value="https://zh.parceljs.org" selected>简体中文</option>
+            <option class="zh-tw" value="https://zh-tw.parceljs.org">繁體中文</option>
+          </select>
+        </form>
+        <a href="https://github.com/parcel-bundler/parcel" target="_blank">GitHub</a>
+      </div>
+    </header>
+    <div class="content">
+      <nav>
+        <ul>
+          <li><a href="getting_started.html">🚀 快速开始</a></li>
+          <li><a href="assets.html">📦 资源</a></li>
+          <li><a href="transforms.html">🐠 转换</a></li>
+          <li><a href="code_splitting.html">✂️ 代码拆分</a></li>
+          <li><a href="hmr.html">🔥 热模块重载</a></li>
+          <li><a href="production.html">✨ 生产环境</a></li>
+          <li><a href="recipes.html">🍰 配方</a></li>
+          <li><a href="cli.html">🖥 CLI</a></li>
+        </ul>
+        <h3>进阶</h3>
+        <ul>
+          <li><a href="how_it_works.html">🛠 它如何运作</a></li>
+          <li><a href="asset_types.html">📝 资源类型</a></li>
+          <li><a href="api.html">📚 API</a></li>
+          <li><a href="packagers.html">📦 Packagers</a></li>
+          <li><a href="plugins.html">🔌 插件</a></li>
+        </ul>
+      </nav>
+      <main>
+        {{~> content}}
+
+        <h2>Help us improve the docs</h2>
+        <p>
+          If something is missing or not entirely clear, please
+          <a href="https://github.com/parcel-bundler/website/issues">file an issue on the website repository</a> or
+          <a href="https://github.com/parcel-bundler/website/edit/master/src/i18n/{{language}}/docs/{{relative}}"
+            >edit this page</a
+          >.
+        </p>
+      </main>
     </div>
-  </header>
-  <div class="content">
-    <nav>
-      <ul>
-        <li><a href="getting_started.html">🚀 快速开始</a></li>
-        <li><a href="assets.html">📦 资源</a></li>
-        <li><a href="transforms.html">🐠 转换</a></li>
-        <li><a href="code_splitting.html">✂️ 代码拆分</a></li>
-        <li><a href="hmr.html">🔥 热模块重载</a></li>
-        <li><a href="production.html">✨ 生产环境</a></li>
-        <li><a href="recipes.html">🍰 配方</a></li>
-        <li><a href="cli.html">🖥 CLI</a></li>
-      </ul>
-      <h3>进阶</h3>
-      <ul>
-        <li><a href="how_it_works.html">🛠 它如何运作</a></li>
-        <li><a href="asset_types.html">📝 资源类型</a></li>
-        <li><a href="api.html">📚 API</a></li>
-        <li><a href="packagers.html">📦 Packagers</a></li>
-        <li><a href="plugins.html">🔌 插件</a></li>
-      </ul>
-    </nav>
-    <main>
-      {{~> content}}
+    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
+    <script type="text/javascript">
+      ;(function() {
+        var pathname = window.location.pathname.substr(1)
+        var activeLink = document.querySelector('a[href="' + pathname + '"]')
 
-      <h2>Help us improve the docs</h2>
-      <p>If something is missing or not entirely clear, please 
-          <a href="https://github.com/parcel-bundler/website/issues">file an issue on the website repository</a> 
-          or <a href="https://github.com/parcel-bundler/website/edit/master/src/i18n/{{language}}/docs/{{relative}}">edit this page</a>.</p>
-    </main>
-  </div>
-  <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
-  <script type="text/javascript">
-    (function () {
-      var pathname = window.location.pathname.substr(1);
-      var activeLink = document.querySelector('a[href="' + pathname + '"]');
+        activeLink.classList.add('selected')
+        if (activeLink.scrollIntoView) activeLink.scrollIntoView()
 
-      activeLink.classList.add('selected');
-
-      docsearch({
-        apiKey: '8b6be780425a72d1a1683abea2636778',
-        indexName: 'parceljs',
-        inputSelector: '#search-input',
-        algoliaOptions: {
-          'facetFilters': [
-            `lang:${LANGUAGE}`
-          ]
-        }
-      });
-    })();
-  </script>
-</body>
+        docsearch({
+          apiKey: '8b6be780425a72d1a1683abea2636778',
+          indexName: 'parceljs',
+          inputSelector: '#search-input',
+          algoliaOptions: {
+            facetFilters: [`lang:${LANGUAGE}`]
+          }
+        })
+      })()
+    </script>
+  </body>
 </html>


### PR DESCRIPTION
This ensures the current page's link is always visible, which is useful when browsing the documentation and reading each of the page. Otherwise the reader has to keep scrolling down the page when they're reading through the later sections. Personally I would prefer if the scroll state is preserved from page to page, but that takes a lot more code. 

This would have been a one line change, but it seems the templates in other languages were not Prettier formatted, so there's a lot more changes than I intended, unfortunately, and it all got smushed into my existed changes automatically by Husky. 