### PR TITLE
Redirect to homepage if page is not found

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -26,5 +26,10 @@ app.use(
   })
 )
 
+app.use(function(req, res, next) {
+  // redirect to homepage if page not found
+  res.redirect(307, req.protocol + '://' + req.get('host'))
+})
+
 app.listen(5000)
 console.log('Listening on port http://localhost:5000')


### PR DESCRIPTION
Currently, if switching to a translation which doesn't have page that corresponds to the current page, an error is printed.

Fixup for #338