### PR TITLE
Add Elm language support documentation.

### DIFF
--- a/src/assets/icon-elm.svg
+++ b/src/assets/icon-elm.svg
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 17.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+   viewBox="0 0 323.141 322.95" enable-background="new 0 0 323.141 322.95" xml:space="preserve">
+<g>
+  <polygon
+    fill="#F0AD00"
+    points="161.649,152.782 231.514,82.916 91.783,82.916"/>
+
+  <polygon
+    fill="#7FD13B"
+    points="8.867,0 79.241,70.375 232.213,70.375 161.838,0"/>
+
+  <rect
+    fill="#7FD13B"
+    x="192.99"
+    y="107.392"
+    transform="matrix(0.7071 0.7071 -0.7071 0.7071 186.4727 -127.2386)"
+    width="107.676"
+    height="108.167"/>
+
+  <polygon
+    fill="#60B5CC"
+    points="323.298,143.724 323.298,0 179.573,0"/>
+
+  <polygon
+    fill="#5A6378"
+    points="152.781,161.649 0,8.868 0,314.432"/>
+
+  <polygon
+    fill="#F0AD00"
+    points="255.522,246.655 323.298,314.432 323.298,178.879"/>
+
+  <polygon
+    fill="#60B5CC"
+    points="161.649,170.517 8.869,323.298 314.43,323.298"/>
+</g>
+</svg>

--- a/src/i18n/en/docs/elm.md
+++ b/src/i18n/en/docs/elm.md
@@ -1,0 +1,43 @@
+# Elm
+
+_Supported extensions: `elm`_
+
+[Elm](https://elm-lang.org/) is a functional language with an advanced type
+system that ensures correctnes of your code and prevents confusing runtime
+errors. With its focus on simplicity and speed, Elm is a great choice when it
+comes to building webapps of all kinds. Parcel supports Elm righ out of the box
+without the need for any additional configuration.
+
+```html
+<!-- index.html -->
+
+<html>
+  <body>
+    <main></main>
+    <script src="./index.js"></script>
+  </body>
+</html>
+```
+
+```javascript
+// index.js
+
+import { Elm } from './Main.elm'
+
+Elm.Main.init({
+  node: document.querySelector('main')
+})
+```
+
+```elm
+-- Main.elm
+
+import Browser
+import Html exposing (h1, text)
+
+main =
+  h1 [] [ text "Hello, Elm!" ]
+```
+
+To learn more about Elm and its ecosystem of tools, see the official
+[guide](https://guide.elm-lang.org/).

--- a/src/i18n/en/layout/page.html
+++ b/src/i18n/en/layout/page.html
@@ -120,6 +120,9 @@
             <a href="webAssembly.html"><img src="assets/icon-webassembly.svg" />WebAssembly</a>
           </li>
           <li>
+            <a href="elm.html"><img src="assets/icon-elm.svg" />Elm</a>
+          </li>
+          <li>
             <a href="yaml.html"><img src="assets/icon-yaml.svg" />YAML</a>
           </li>
           <li>


### PR DESCRIPTION
While Parcel has a stellar support fort Elm language right out of the box, there is no mention of this feature in the official documentation. This PR should fix that.

The Elm logo was taken from the [elm/foundation.elm-lang.org](https://github.com/elm/foundation.elm-lang.org) repository.