### PR TITLE
rename all references in docs from 'parcel-bundler' to 'parcel'

### DIFF
--- a/src/i18n/en/docs/api.md
+++ b/src/i18n/en/docs/api.md
@@ -6,7 +6,7 @@ Instead of the CLI you can also use the API to initialise a bundler, for more ad
 A watch example with every option explained:
 
 ```Javascript
-const Bundler = require('parcel-bundler');
+const Bundler = require('parcel');
 const Path = require('path');
 
 // Single entrypoint file location:
@@ -165,7 +165,7 @@ Middleware can be used to hook into an http server (e.g. `express` or node `http
 An example of using the Parcel middleware with express
 
 ```Javascript
-const Bundler = require('parcel-bundler');
+const Bundler = require('parcel');
 const app = require('express')();
 
 const file = 'index.html'; // Pass an absolute path to the entrypoint here

--- a/src/i18n/en/docs/asset_types.md
+++ b/src/i18n/en/docs/asset_types.md
@@ -7,7 +7,7 @@ Because Parcel processes assets in parallel across multiple processor cores, the
 ## Asset Interface
 
 ```javascript
-const { Asset } = require('parcel-bundler')
+const { Asset } = require('parcel')
 
 class MyAsset extends Asset {
   type = 'foo' // set the main output type.
@@ -60,7 +60,7 @@ module.exports = MyAsset
 You can register your asset type with a bundler using the `addAssetType` method. It accepts a file extension to register, and the path to your asset type module. It is a path rather than the actual object so that it can be passed to worker processes.
 
 ```javascript
-const Bundler = require('parcel-bundler')
+const Bundler = require('parcel')
 
 let bundler = new Bundler('input.js')
 bundler.addAssetType('.ext', require.resolve('./MyAsset'))

--- a/src/i18n/en/docs/env.md
+++ b/src/i18n/en/docs/env.md
@@ -2,7 +2,7 @@
 
 Parcel uses [dotenv](https://github.com/motdotla/dotenv) to support loading environment variables from `.env` files.
 
-`.env` files are to be stored alongside the `package.json` that contains your `parcel-bundler` dependency.
+`.env` files are to be stored alongside the `package.json` that contains your `parcel` dependency.
 
 Parcel loads `.env` files with these specific names for the following `NODE_ENV` values:
 

--- a/src/i18n/en/docs/getting_started.md
+++ b/src/i18n/en/docs/getting_started.md
@@ -7,13 +7,13 @@ First install Parcel using Yarn or npm:
 Yarn:
 
 ```bash
-yarn global add parcel-bundler
+yarn global add parcel
 ```
 
 npm:
 
 ```bash
-npm install -g parcel-bundler
+npm install -g parcel
 ```
 
 Create a package.json file in your project directory using:
@@ -34,9 +34,9 @@ Next, create an index.html and index.js file.
 
 ```html
 <html>
-<body>
-  <script src="./index.js"></script>
-</body>
+  <body>
+    <script src="./index.js"></script>
+  </body>
 </html>
 ```
 
@@ -96,13 +96,13 @@ Sometimes it's not possible to install Parcel globally e.g. if you're building o
 To install with Yarn:
 
 ```bash
-yarn add parcel-bundler --dev
+yarn add parcel --dev
 ```
 
 To install with NPM:
 
 ```bash
-npm install parcel-bundler --save-dev
+npm install parcel --save-dev
 ```
 
 Then, add these tasks scripts to your project, by modifying your `package.json`:

--- a/src/i18n/en/docs/module_resolution.md
+++ b/src/i18n/en/docs/module_resolution.md
@@ -3,9 +3,11 @@
 The Parcel resolver implements a modified version of [the node_modules resolution](https://nodejs.org/api/modules.html#modules_all_together) algorithm.
 
 ## Module resolution
+
 In addition to the standard algorithm, all [asset types supported by Parcel](https://parceljs.org/assets.html) are also resolved.
 
 Module resolution can be relative to the:
+
 - **entry root**: the directory of the entrypoint specified to Parcel, or the shared root (common parent directory) when multiple entrypoints are specified.
 - **package root**: the directory of the nearest module root in `node_modules`.
 
@@ -25,13 +27,14 @@ This example bundles a directory of png files and returns the dist URLs.
 
 ```
 import foo from "/assets/*.png";
-// { 
+// {
 //   'file-1': '/file-1.8e73c985.png',
 //   'file-2': '/file-1.8e73c985.png'
 // }
 ```
 
 ### package.json `browser` field
+
 If a package includes a [package.browser field](https://docs.npmjs.com/files/package.json#browser), Parcel will use this instead of the package.main entry.
 
 ### Aliases
@@ -45,7 +48,7 @@ This example aliases `react` to `preact` and some local custom module that is no
 {
   "name": "some-package",
   "devDependencies": {
-    "parcel-bundler": "^1.7.0"
+    "parcel": "^1.7.0"
   },
   "alias": {
     "react": "preact-compat",

--- a/src/i18n/en/docs/packagers.md
+++ b/src/i18n/en/docs/packagers.md
@@ -5,7 +5,7 @@ In Parcel, a `Packager` combines multiple `Asset`s together into a final output 
 ## Packager Interface
 
 ```javascript
-const { Packager } = require('parcel-bundler')
+const { Packager } = require('parcel')
 
 class MyPackager extends Packager {
   async start() {
@@ -32,7 +32,7 @@ module.exports = MyPackager
 You can register your packager with a bundler using the `addPackager` method. It accepts a file type to register, and the path to your packager module.
 
 ```javascript
-const Bundler = require('parcel-bundler')
+const Bundler = require('parcel')
 
 let bundler = new Bundler('input.js')
 bundler.addPackager('foo', require.resolve('./MyPackager'))

--- a/src/i18n/en/docs/recipes.md
+++ b/src/i18n/en/docs/recipes.md
@@ -9,7 +9,7 @@ First we need to install the dependencies for React.
 ```bash
 npm install --save react
 npm install --save react-dom
-npm install --save-dev parcel-bundler
+npm install --save-dev parcel
 ```
 
 <sub>Or if you have the optional Yarn package manager installed</sub>
@@ -17,7 +17,7 @@ npm install --save-dev parcel-bundler
 ```bash
 yarn add react
 yarn add react-dom
-yarn add --dev parcel-bundler
+yarn add --dev parcel
 ```
 
 Add Start script to `package.json`
@@ -36,7 +36,7 @@ First we need to install the dependencies for Preact.
 ```bash
 npm install --save preact
 npm install --save preact-compat
-npm install --save-dev parcel-bundler
+npm install --save-dev parcel
 npm install --save-dev babel-preset-preact
 ```
 
@@ -45,7 +45,7 @@ npm install --save-dev babel-preset-preact
 ```bash
 yarn add preact
 yarn add preact-compat
-yarn add --dev parcel-bundler
+yarn add --dev parcel
 yarn add --dev babel-preset-preact
 ```
 
@@ -75,14 +75,14 @@ First we need to install the dependencies for Vue.
 
 ```bash
 npm install --save vue
-npm install --save-dev parcel-bundler
+npm install --save-dev parcel
 ```
 
 <sub>Or if you have the optional Yarn package manager installed</sub>
 
 ```bash
 yarn add vue
-yarn add --dev parcel-bundler
+yarn add --dev parcel
 ```
 
 Add Start script to `package.json`
@@ -100,14 +100,14 @@ First we need to add Parcel and Typescript to our project.
 
 ```bash
 npm install --save-dev typescript
-npm install --save-dev parcel-bundler
+npm install --save-dev parcel
 ```
 
 <sub>Or if you have the optional Yarn package manager installed</sub>
 
 ```bash
 yarn add typescript --dev
-yarn add --dev parcel-bundler
+yarn add --dev parcel
 ```
 
 ### Compiling from index.html
@@ -127,12 +127,11 @@ Then, in your `index.html` file, simply reference your `.ts` file.
 <!-- index.html -->
 <!DOCTYPE html>
 <html lang="en">
-<head>
-</head>
-<body>
+  <head> </head>
+  <body>
     <!-- Here 👇 -->
     <script src="./myTypescriptFile.ts"></script>
-</body>
+  </body>
 </html>
 ```
 


### PR DESCRIPTION
Upon importing `parcel-bundler` from node (using parcel's api), `eslint-plugin-import` will fail to resolve the package. This PR fixes that issue