### PR TITLE
Update cli.md

### DIFF
--- a/src/i18n/en/docs/cli.md
+++ b/src/i18n/en/docs/cli.md
@@ -18,6 +18,15 @@ Builds the assets once, it also enabled minification and sets the `NODE_ENV=prod
 parcel build index.html
 ```
 
+_NOTE:_ For special use cases, it's also possible to perform a single build from the `development` environment, like this:
+
+```
+NODE_ENV=development parcel build <entrypoint> --no-minify
+```
+
+It creates the same bundles than `serve`, but it doesn't watch or serve assets.
+
+
 ### Watch
 
 The `watch` command is similar to `serve`, with the main difference being it doesn't start up a server.


### PR DESCRIPTION
Add a note to `build` command, about the possibility of performing a single build from `development` without starting to watch for changes or serve any assets.

This has been talked in https://github.com/parcel-bundler/parcel/issues/2540 and, even when that question is not closed, I faced the same problem and a note like this just here would have saved me a few hours trying to figure how to do this (and I tried a lot of things in that time).
Well, basically I wanted to to do a first dev serve and then do some other stuff and then watch. Knowing about this option allows me to do what I want, so I hope it could also help other people and save them time.

Thanks to @DeMoorJasper for suggesting this solution in the aforementioned issue :+1: