### PR TITLE
Remove the word "just" from instructions

### DIFF
--- a/src/i18n/en/index.html
+++ b/src/i18n/en/index.html
@@ -152,7 +152,7 @@ main();</code></pre>
         </div>
 
         <p>
-          Just run <code>parcel index.html</code> to start a dev server. Importing JavaScript, CSS, images, and more
+          Run <code>parcel index.html</code> to start a dev server. Importing JavaScript, CSS, images, and more
           just works! 👌
         </p>
       </section>


### PR DESCRIPTION
Thought the intention was probably to demonstrate how easy the process is, using the word "just" can be dismissive and make people feel bad:

http://bradfrost.com/blog/post/just/