### PR TITLE
Remove the word "just"

### DIFF
--- a/src/i18n/en/docs/getting_started.md
+++ b/src/i18n/en/docs/getting_started.md
@@ -44,7 +44,7 @@ Next, create an index.html and index.js file.
 console.log('hello world')
 ```
 
-Parcel has a development server built in, which will automatically rebuild your app as you change files and supports [hot module replacement](hmr.html) for fast development. Just point it at your entry file:
+Parcel has a development server built in, which will automatically rebuild your app as you change files and supports [hot module replacement](hmr.html) for fast development. Point it at your entry file:
 
 ```bash
 parcel index.html


### PR DESCRIPTION
Using the word "just" before an instruction can feel belittling:

http://bradfrost.com/blog/post/just/