### PR TITLE
Add Japanese to language list in layout

### DIFF
--- a/src/i18n/en/layout/page.html
+++ b/src/i18n/en/layout/page.html
@@ -44,6 +44,7 @@
             <option class="es" value="https://es.parceljs.org">Español</option>
             <option class="fr" value="https://fr.parceljs.org">Français</option>
             <option class="it" value="https://it.parceljs.org">Italiano</option>
+            <option class="ja" value="https://ja.parceljs.org">日本語</option>
             <option class="ko" value="https://ko.parceljs.org">한국어</option>
             <option class="pl" value="https://pl.parceljs.org">Polskie</option>
             <option class="pt" value="https://pt.parceljs.org">Português</option>

--- a/src/i18n/es/layout/page.html
+++ b/src/i18n/es/layout/page.html
@@ -44,6 +44,7 @@
             <option class="es" value="https://es.parceljs.org" selected>Español</option>
             <option class="fr" value="https://fr.parceljs.org">Français</option>
             <option class="it" value="https://it.parceljs.org">Italiano</option>
+            <option class="ja" value="https://ja.parceljs.org">日本語</option>
             <option class="ko" value="https://ko.parceljs.org">한국어</option>
             <option class="pl" value="https://pl.parceljs.org">Polskie</option>
             <option class="pt" value="https://pt.parceljs.org">Português</option>

--- a/src/i18n/fr/layout/page.html
+++ b/src/i18n/fr/layout/page.html
@@ -44,6 +44,7 @@
             <option class="es" value="https://es.parceljs.org">Español</option>
             <option class="fr" value="https://fr.parceljs.org" selected>Français</option>
             <option class="it" value="https://it.parceljs.org">Italiano</option>
+            <option class="ja" value="https://ja.parceljs.org">日本語</option>
             <option class="ko" value="https://ko.parceljs.org">한국어</option>
             <option class="pl" value="https://pl.parceljs.org">Polskie</option>
             <option class="pt" value="https://pt.parceljs.org">Português</option>

--- a/src/i18n/it/layout/page.html
+++ b/src/i18n/it/layout/page.html
@@ -44,6 +44,7 @@
             <option class="es" value="https://es.parceljs.org">Español</option>
             <option class="fr" value="https://fr.parceljs.org">Français</option>
             <option class="it" value="https://it.parceljs.org" selected>Italiano</option>
+            <option class="ja" value="https://ja.parceljs.org">日本語</option>
             <option class="ko" value="https://ko.parceljs.org">한국어</option>
             <option class="pl" value="https://pl.parceljs.org">Polskie</option>
             <option class="pt" value="https://pt.parceljs.org">Português</option>

--- a/src/i18n/ko/layout/page.html
+++ b/src/i18n/ko/layout/page.html
@@ -45,6 +45,7 @@
             <option class="es" value="https://es.parceljs.org">Español</option>
             <option class="fr" value="https://fr.parceljs.org">Français</option>
             <option class="it" value="https://it.parceljs.org">Italiano</option>
+            <option class="ja" value="https://ja.parceljs.org">日本語</option>
             <option class="ko" value="https://ko.parceljs.org" selected>한국어</option>
             <option class="pl" value="https://pl.parceljs.org">Polskie</option>
             <option class="pt" value="https://pt.parceljs.org">Português</option>

--- a/src/i18n/pl/layout/page.html
+++ b/src/i18n/pl/layout/page.html
@@ -44,6 +44,7 @@
             <option class="es" value="https://es.parceljs.org">Español</option>
             <option class="fr" value="https://fr.parceljs.org">Français</option>
             <option class="it" value="https://it.parceljs.org">Italiano</option>
+            <option class="ja" value="https://ja.parceljs.org">日本語</option>
             <option class="ko" value="https://ko.parceljs.org">한국어</option>
             <option class="pl" value="https://pl.parceljs.org" selected>Polskie</option>
             <option class="pt" value="https://pt.parceljs.org">Português</option>

--- a/src/i18n/pt/layout/page.html
+++ b/src/i18n/pt/layout/page.html
@@ -44,6 +44,7 @@
             <option class="es" value="https://es.parceljs.org">Español</option>
             <option class="fr" value="https://fr.parceljs.org">Français</option>
             <option class="it" value="https://it.parceljs.org">Italiano</option>
+            <option class="ja" value="https://ja.parceljs.org">日本語</option>
             <option class="ko" value="https://ko.parceljs.org">한국어</option>
             <option class="pl" value="https://pl.parceljs.org">Polskie</option>
             <option class="pt" value="https://pt.parceljs.org" selected>Português</option>

--- a/src/i18n/ru/layout/page.html
+++ b/src/i18n/ru/layout/page.html
@@ -44,6 +44,7 @@
             <option class="es" value="https://es.parceljs.org">Español</option>
             <option class="fr" value="https://fr.parceljs.org">Français</option>
             <option class="it" value="https://it.parceljs.org">Italiano</option>
+            <option class="ja" value="https://ja.parceljs.org">日本語</option>
             <option class="ko" value="https://ko.parceljs.org">한국어</option>
             <option class="pl" value="https://pl.parceljs.org">Polskie</option>
             <option class="pt" value="https://pt.parceljs.org">Português</option>

--- a/src/i18n/uk/layout/page.html
+++ b/src/i18n/uk/layout/page.html
@@ -44,6 +44,7 @@
             <option class="es" value="https://es.parceljs.org">Español</option>
             <option class="fr" value="https://fr.parceljs.org">Français</option>
             <option class="it" value="https://it.parceljs.org">Italiano</option>
+            <option class="ja" value="https://ja.parceljs.org">日本語</option>
             <option class="ko" value="https://ko.parceljs.org">한국어</option>
             <option class="pl" value="https://pl.parceljs.org">Polskie</option>
             <option class="pt" value="https://pt.parceljs.org">Português</option>

--- a/src/i18n/zh-tw/layout/page.html
+++ b/src/i18n/zh-tw/layout/page.html
@@ -33,6 +33,7 @@
           <option class="es" value="https://es.parceljs.org">Español</option>
           <option class="fr" value="https://fr.parceljs.org">Français</option>
           <option class="it" value="https://it.parceljs.org">Italiano</option>
+          <option class="ja" value="https://ja.parceljs.org">日本語</option>
           <option class="ko" value="https://ko.parceljs.org">한국어</option>
           <option class="pl" value="https://pl.parceljs.org">Polskie</option>
           <option class="pt" value="https://pt.parceljs.org">Português</option>

--- a/src/i18n/zh/layout/page.html
+++ b/src/i18n/zh/layout/page.html
@@ -34,6 +34,7 @@
           <option class="es" value="https://es.parceljs.org">Español</option>
           <option class="fr" value="https://fr.parceljs.org">Français</option>
           <option class="it" value="https://it.parceljs.org">Italiano</option>
+          <option class="ja" value="https://ja.parceljs.org">日本語</option>
           <option class="ko" value="https://ko.parceljs.org">한국어</option>
           <option class="pl" value="https://pl.parceljs.org">Polskie</option>
           <option class="pt" value="https://pt.parceljs.org">Português</option>


### PR DESCRIPTION
Include Japanese into the language list shown in individual pages.

Before:
![1](https://user-images.githubusercontent.com/40988246/53133507-b647f580-35b6-11e9-8a45-aa2ca3bff957.png)
After:
![2](https://user-images.githubusercontent.com/40988246/53133513-bba54000-35b6-11e9-87e9-0b9ad7b80344.png)

Follow up to #382.
