### PR TITLE
Synchronizing portuguese documentation

### DIFF
--- a/src/i18n/en/docs/cli.md
+++ b/src/i18n/en/docs/cli.md
@@ -161,7 +161,7 @@ parcel entry.js --log-level 1
 | 1        | Only log errors                                                                                 |
 | 2        | Log errors and warnings                                                                         |
 | 3        | Log errors, warnings and info                                                                   |
-| 4        | Verbose (keep everything in log with timestamps <br/> and also log http requests to dev server) |
+| 4        | Verbose (keep everything in log with timestamps <br> and also log http requests to dev server) |
 | 5        | Debug (save everything to a file with timestamps)                                               |
 
 ### HMR Hostname

--- a/src/i18n/en/docs/css.md
+++ b/src/i18n/en/docs/css.md
@@ -7,6 +7,7 @@ CSS assets can be imported from a JavaScript or HTML file:
 ```js
 import './index.css';
 ```
+
 ```html
 <link rel="stylesheet" type="text/css" href="index.css">
 ```
@@ -25,7 +26,7 @@ CSS assets can contain dependencies referenced by `@import` syntax as well as re
 
 In addition to plain CSS, other compile-to-CSS languages like LESS, SASS, and Stylus are also supported, and work the same way.
 
-# PostCSS
+## PostCSS
 
 [PostCSS](http://postcss.org) is a tool for transforming CSS with plugins, like [autoprefixer](https://github.com/postcss/autoprefixer), [Preset Env](https://github.com/csstools/postcss-preset-env), and [CSS Modules](https://github.com/css-modules/css-modules). You can configure PostCSS with Parcel by creating a configuration file using one of these names: `.postcssrc` (JSON), `.postcssrc.js`, or `postcss.config.js`.
 
@@ -59,11 +60,11 @@ last 2 versions
 
 CSS Modules are enabled slightly differently using the a top-level `modules` key. This is because Parcel needs to have special support for CSS Modules since they export an object to be included in the JavaScript bundle as well. Note that you still need to install `postcss-modules` in your project.
 
-## Usage with existing CSS libraries
+### Usage with existing CSS libraries
 
 For CSS Modules to work properly with existing modules they need to specify this support in their own `.postcssrc`.
 
-## Set cssnano minify config
+### Set cssnano minify config
 
 Parcel adds [cssnano](http://cssnano.co) to postcss in order to minify css in production build, where custom configuration can be set by creating `cssnano.config.js` file:
 

--- a/src/i18n/en/docs/elm.md
+++ b/src/i18n/en/docs/elm.md
@@ -2,11 +2,7 @@
 
 _Supported extensions: `elm`_
 
-[Elm](https://elm-lang.org/) is a functional language with an advanced type
-system that ensures correctnes of your code and prevents confusing runtime
-errors. With its focus on simplicity and speed, Elm is a great choice when it
-comes to building webapps of all kinds. Parcel supports Elm right out of the box
-without the need for any additional configuration.
+[Elm](https://elm-lang.org/) is a functional language with an advanced type system that ensures correctness of your code and prevents confusing runtime errors. With its focus on simplicity and speed, Elm is a great choice when it comes to building webapps of all kinds. Parcel supports Elm right out of the box without the need for any additional configuration.
 
 ```html
 <!-- index.html -->
@@ -40,5 +36,4 @@ main =
   h1 [] [ text "Hello, Elm!" ]
 ```
 
-To learn more about Elm and its ecosystem of tools, see the official
-[guide](https://guide.elm-lang.org/).
+To learn more about Elm and its ecosystem of tools, see the [official guide](https://guide.elm-lang.org/).

--- a/src/i18n/en/docs/getting_started.md
+++ b/src/i18n/en/docs/getting_started.md
@@ -58,7 +58,7 @@ Use the development server when you don't have your own server, or your app is e
 parcel watch index.html
 ```
 
-### Multiple entry files
+## Multiple entry files
 
 In case you have more than one entry file, let's say `index.html` and `about.html`, you have 2 ways to run the bundler:
 
@@ -85,11 +85,11 @@ _NOTE:_ In case you have a file structure like this:
 
 Going to http://localhost:1234/folder-1/ won't work, instead you will need to explicitly point to the file http://localhost:1234/folder-1/index.html.
 
-### Building for production
+## Building for production
 
 When you're ready to build for production, the `build` mode turns off watching and only builds once. See the [Production](production.html) section for more details.
 
-### Adding parcel to your project
+## Adding parcel to your project
 
 Sometimes it's not possible to install Parcel globally e.g. if you're building on someone else's build agent or you want to use a CI to build your project programmatically. In this case, you can install and run Parcel as a local package.
 

--- a/src/i18n/en/docs/javascript.md
+++ b/src/i18n/en/docs/javascript.md
@@ -52,7 +52,7 @@ const buffer = fs.readFileSync(__dirname + '/test.png')
 ;<img src={`data:image/png;base64,${buffer.toString('base64')}`} />
 ```
 
-### Images in JSX
+## Images in JSX
 
 Below is an example of how you could import an image file for use in JSX.
 
@@ -67,7 +67,7 @@ import megaMan from "./images/mega-man.png";
 <img src={`/dist${megaMan}`} title="Mega Man" alt="Mega Man" />
 ```
 
-# Babel
+## Babel
 
 [Babel](https://babeljs.io) is a popular transpiler for JavaScript, with a large plugin ecosystem. Using Babel with Parcel works the same way as using it standalone or with other bundlers.
 
@@ -84,12 +84,15 @@ Then, create a `.babelrc`:
   "presets": ["@babel/preset-react"]
 }
 ```
+
 You can also put `babel` config in `package.json`
+
 ```json
 "babel": {
   "presets": ["@babel/preset-react"]
 }
 ```
+
 NOTE: `package.json` takes precedence over `.babelrc`.
 
 ## Default Babel transforms
@@ -102,7 +105,7 @@ The browserlist target defaults to: `> 0.25%` (Meaning, support every browser th
 
 For the `node` target, Parcel uses the `engines.node` defined in `package.json`, this default to _node 8_.
 
-# Flow
+## Flow
 
 [Flow](https://flow.org/) is a popular static type checker for JavaScript. Using Flow with Parcel is as simple as placing `// @flow` as the first line of your `js` files.
 

--- a/src/i18n/en/docs/module_resolution.md
+++ b/src/i18n/en/docs/module_resolution.md
@@ -3,9 +3,11 @@
 The Parcel resolver implements a modified version of [the node_modules resolution](https://nodejs.org/api/modules.html#modules_all_together) algorithm.
 
 ## Module resolution
+
 In addition to the standard algorithm, all [asset types supported by Parcel](https://parceljs.org/assets.html) are also resolved.
 
 Module resolution can be relative to the:
+
 - **entry root**: the directory of the entrypoint specified to Parcel, or the shared root (common parent directory) when multiple entrypoints are specified.
 - **package root**: the directory of the nearest module root in `node_modules`.
 
@@ -19,19 +21,20 @@ Module resolution can be relative to the:
 
 ### Glob file paths
 
-Globs are wildcard imports that bundle multiple assets at once. Globs can match some or all files (`/assets/*.png`), as well as files in multiple directories (`/assets/**/*`);
+Globs are wildcard imports that bundle multiple assets at once. Globs can match some or all files (`/assets/*.png`), as well as files in multiple directories (`/assets/**/*`)
 
 This example bundles a directory of png files and returns the dist URLs.
 
-```
+```javascript
 import foo from "/assets/*.png";
-// { 
+// {
 //   'file-1': '/file-1.8e73c985.png',
 //   'file-2': '/file-1.8e73c985.png'
 // }
 ```
 
 ### package.json `browser` field
+
 If a package includes a [package.browser field](https://docs.npmjs.com/files/package.json#browser), Parcel will use this instead of the package.main entry.
 
 ### Aliases
@@ -115,7 +118,7 @@ We need Flow to replace the leading `/` in `'/components/apple'` with `src/`, re
 
 The following setting in our `.flowconfig` achieves this replacement:
 
-```
+```ini
 [options]
 module.name_mapper='^\/\(.*\)$' -> '<PROJECT_ROOT>/src/\1'
 ```

--- a/src/i18n/en/docs/production.md
+++ b/src/i18n/en/docs/production.md
@@ -24,7 +24,7 @@ if (process.env.NODE_ENV === 'development') { // Or, `process.env.NODE_ENV !== '
 
 To allow setting very aggresive caching rules to your cdn, for optimal performance and efficiency, Parcel hashes the file names of most bundles (according to whether the bundle should have a readable/rememberable name or not, mainly for SEO).
 
-Parcel follows the following table, when it comes to naming bundles. (Entrypoints are never hashed)
+Parcel follows the following table, when it comes to naming bundles (Entrypoints are never hashed).
 
 |                   Bundle Type | Type               | Content hashed |
 | ----------------------------: | ------------------ | :------------: |

--- a/src/i18n/en/docs/pug.md
+++ b/src/i18n/en/docs/pug.md
@@ -2,21 +2,25 @@
 
 _Supported extensions: `jade`, `pug`_
 
-Setting Pug up is easy. You can have any file structure you want, I am only providing several simple examples as a point of reference. 
+Setting Pug up is easy. You can have any file structure you want, I am only providing several simple examples as a point of reference.
 
 ## Example 1 - Just index.pug
+
 Let's assume this file structure:
+
 ```bash
 .
 ├── package.json
 └── src
     └── index.pug
 ```
+
 We can get this running by using this parcel command: `parcel src/index.pug`.
 
-
 ## Example 2 - index.pug, index.js and style.css
+
 Let's assume this file structure:
+
 ```bash
 .
 ├── package.json
@@ -26,7 +30,7 @@ Let's assume this file structure:
     └── style.css
 ```
 
-Inside index.pug, just wire up your stylesheet and js as usual. 
+Inside index.pug, just wire up your stylesheet and js as usual.
 
 ```pug
 // index.pug
@@ -37,16 +41,19 @@ html(lang="")
     // ...
     link(rel="stylesheet", href="index.css")
   body
-    h1 Hello 
+    h1 Hello
 
     script(src="index.js")
 ```
-If you were using Stylus, Sass or LESS, you would still wire it up the same way. You can import your style file directly into your JS file if you prefer. 
+
+If you were using Stylus, Sass or LESS, you would still wire it up the same way. You can import your style file directly into your JS file if you prefer.
 
 We can get this running by using the same parcel command: `parcel src/index.pug`.
 
 ## Example 3 - Pug with locals
+
 Let's assume this file structure:
+
 ```bash
 .
 ├── package.json
@@ -54,7 +61,9 @@ Let's assume this file structure:
     ├── index.pug
     └── pug.config.js
 ```
+
 We need to export a `locals` object from a `pug.config.js` file. The `pug.config.js` file must be in the directory with the `index.pug` file OR, in the directory containing the `package.json` file. The `pug.config.js` file does not need to be imported into a js file explicitly. This **IS** the only way to make a `locals` object available for your Pug templates.
+
 ```js
 // pug.config.js
 
@@ -64,6 +73,7 @@ module.exports = {
   }
 };
 ```
+
 ```pug
 // index.pug
 
@@ -72,23 +82,29 @@ html(lang="")
   head
     // ...
   body
-    h1 #{hello} 
+    h1 #{hello}
 ```
-Again, we can get this running by using the same parcel command: `parcel src/index.pug`. 
+
+Again, we can get this running by using the same parcel command: `parcel src/index.pug`.
 
 ### Cancel and rerun parcel after updating locals object
+
 You will not be able to see changes made to your `locals` object on the fly.  If you update your `locals` object, you will need to cancel the parcel process in your terminal and relaunch `parcel src/index.pug` again.
 
 ### Watch our for silent errors
+
 Also, understand that if you use this locals setup, you will not get an error if you use a property that doesn't exist for interpolation in your Pug. Thus, if we wrote `h1 #{thing}` and there was no `thing` property in locals, then Parcel will not crash, nor report an error. You will only be left with an empty result in the browser. So, be careful to get this right, or you might not know that an interpolated element is not working.
 
 ### Three file naming options only
+
 You can use a `.pugrc` or a `.pugrc.js` file instead of `pug.config.js`. But these are the only 3 variations that will work for setting up locals.
 
 ### Can't use import statements in the `pug.config.js` file
-If you want to import other files into the `pug.config.js` file, then you must use require statements. 
+
+If you want to import other files into the `pug.config.js` file, then you must use require statements.
 
 This will work:
+
 ```js
 // pug.config.js
 
@@ -101,7 +117,9 @@ module.exports = {
 };
 
 ```
+
 This will NOT work:
+
 ```js
 import data from "./data.js";
 
@@ -112,8 +130,8 @@ module.exports = {
 };
 ```
 
-
 ## Adding a script to package.json
+
 ```json
 "scripts": {
     "dev": "parcel src/index.pug",
@@ -121,4 +139,5 @@ module.exports = {
     "build": "parcel build src/index.pug"
   },
 ```
+
 We can key `npm run dev` or `npm run devopen` to have the project open in the browser. We can then build the pub project with `npm run build`.

--- a/src/i18n/en/docs/pug.md
+++ b/src/i18n/en/docs/pug.md
@@ -51,24 +51,18 @@ Let's assume this file structure:
 .
 ├── package.json
 └── src
-    ├── data.js
-    ├── index.js
-    └── index.pug
+    ├── index.pug
+    └── pug.config.js
 ```
-We need to export a `locals` object and import it into our index.js file
+We need to export a `locals` object from a `pug.config.js` file. The `pug.config.js` file must be in the directory with the `index.pug` file OR, in the directory containing the `package.json` file. The `pug.config.js` file does not need to be imported into a js file explicitly. This **IS** the only way to make a `locals` object available for your Pug templates.
 ```js
-// data.js
+// pug.config.js
 
 module.exports = {
   locals: {
     hello: "world"
   }
 };
-```
-```js
-// index.js
-
-import "./data.js";
 ```
 ```pug
 // index.pug
@@ -79,12 +73,45 @@ html(lang="")
     // ...
   body
     h1 #{hello} 
-
-    script(src="index.js")
 ```
 Again, we can get this running by using the same parcel command: `parcel src/index.pug`. 
 
+### Cancel and rerun parcel after updating locals object
 You will not be able to see changes made to your `locals` object on the fly.  If you update your `locals` object, you will need to cancel the parcel process in your terminal and relaunch `parcel src/index.pug` again.
+
+### Watch our for silent errors
+Also, understand that if you use this locals setup, you will not get an error if you use a property that doesn't exist for interpolation in your Pug. Thus, if we wrote `h1 #{thing}` and there was no `thing` property in locals, then Parcel will not crash, nor report an error. You will only be left with an empty result in the browser. So, be careful to get this right, or you might not know that an interpolated element is not working.
+
+### Three file naming options only
+You can use a `.pugrc` or a `.pugrc.js` file instead of `pug.config.js`. But these are the only 3 variations that will work for setting up locals.
+
+### Can't use import statements in the `pug.config.js` file
+If you want to import other files into the `pug.config.js` file, then you must use require statements. 
+
+This will work:
+```js
+// pug.config.js
+
+const data = require("./data.js");
+
+module.exports = {
+  locals: {
+    d: data
+  }
+};
+
+```
+This will NOT work:
+```js
+import data from "./data.js";
+
+module.exports = {
+  locals: {
+    d: data
+  }
+};
+```
+
 
 ## Adding a script to package.json
 ```json

--- a/src/i18n/en/docs/typeScript.md
+++ b/src/i18n/en/docs/typeScript.md
@@ -25,6 +25,7 @@ export default 'Hello, world'
 ```
 
 ## When using React
+
 To use Typescript + React + JSX, you need to:
 
 1. use the `.tsx` extension
@@ -32,6 +33,7 @@ To use Typescript + React + JSX, you need to:
 3. use a tsconfig with a [special option](https://www.typescriptlang.org/docs/handbook/jsx.html) `"jsx": "react"`
 
 Full example:
+
 ```html
 <!-- index.html -->
 <html>
@@ -50,8 +52,8 @@ import ReactDOM from 'react-dom'
 console.log('Hello from tsx!')
 
 ReactDOM.render(
-	<p>Hello</p>,
-	document.getElementById('root'),
+  <p>Hello</p>,
+  document.getElementById('root'),
 )
 ```
 
@@ -64,4 +66,4 @@ ReactDOM.render(
 }
 ```
 
-See this full thread for more details: https://github.com/parcel-bundler/parcel/issues/1199
+See [this full thread](https://github.com/parcel-bundler/parcel/issues/1199) for more details.

--- a/src/i18n/en/docs/vue.md
+++ b/src/i18n/en/docs/vue.md
@@ -20,6 +20,7 @@ Vue.js is a progressive, incrementally-adoptable JavaScript framework for buildi
 ```
 
 You can use all tools you like (Pug, TypeScript, SCSS, ...):
+
 ```vue
 // app.vue
 <template lang="pug">

--- a/src/i18n/en/docs/vue.md
+++ b/src/i18n/en/docs/vue.md
@@ -19,7 +19,7 @@ Vue.js is a progressive, incrementally-adoptable JavaScript framework for buildi
 
 ```
 
-NOTE: that you can use all tools you like ( pug, typescript, scss ... ), parcel will handle all!
+You can use all tools you like (Pug, TypeScript, SCSS, ...):
 ```vue
 // app.vue
 <template lang="pug">
@@ -50,22 +50,5 @@ export default Vue.extend({
 import Vue from 'vue';
 import App from './app.vue';
 
-Vue.component('app', App);
-
-new Vue({
-  el: '#app',
-  template: `<app></app>`,
-});
-
+new Vue(App).$mount('#app')
 ```
-
-Then simply build the project:
-```bash
-parcel build index.html
-```
-Or serve it ( http://127.0.0.1:1234 ):
-```bash
-parcel index.html
-```
-
-Parcel will automagically add all javascripts and stylesheets!

--- a/src/i18n/ja/docs/transforms.md
+++ b/src/i18n/ja/docs/transforms.md
@@ -1,12 +1,12 @@
-# 🐠 Transforms
+# 🐠 変換
 
-While many bundlers require you to install and configure plugins to transform assets, Parcel has support for many common transforms and transpilers built in out of the box. You can transform JavaScript using [Babel](https://babeljs.io), CSS using [PostCSS](http://postcss.org), and HTML using [PostHTML](https://github.com/posthtml/posthtml). Parcel automatically runs these transforms when it finds a configuration file (e.g. `.babelrc`, `.postcssrc`) in a module. (In addition to any transforms specified in `.babelrc`, Parcel always uses Babel on all modules to compile modern JavaScript into a form supported by browsers. See the [JavaScript/Default Babel Transforms](javascript.html#default-babel-transforms) section for more information.)
+多くのバンドラーがアセットを変換するのにプラグインのインストールと設定を必要としますが、Parcel は多くの一般的な変換とトランスパイラを設定不要で使うことができます。JavaScript へは[Babel](https://babeljs.io)を、CSS へは[PostCSS](http://postcss.org)を、HTML へは[PostHTML](https://github.com/posthtml/posthtml)を使って変換することができます。Parcel はこれらの変換を、モジュールに設定ファイル(例:`.babelrc`, `.postcssrc`)があれば自動的に行います。(`.babelrc`で指定された変換に加えて、Parcel は常に最新の JavaScript をブラウザがサポートする形に変換するために Babel を使います。詳しくは [JavaScript/Babel のデフォルト変換](javascript.html#default-babel-transforms) を参照してください。)
 
-## Third-Party Modules
+## サードパーティ製のモジュール
 
-Configuration files (such as `.babelrc`) will not be applied to files inside third-party `node_modules` by default. However, if the module's directory is symlinked (as is common in some monorepo conventions) and the module's `package.json` has the `source` field set, then configuration files inside the module's directory will be respected. Here are the types of values supported by the `source` field:
+`.babelrc`のような設定ファイルは、デフォルトではサードパーティの`node_modules`に対しては適用されません。しかしながら、モジュールのディレクトリに対してシンボリックリンクが張られていて(いくつかの monorepo 規則では一般的)、モジュールの`package.json`が`source`のフィールドセットを持つ場合には、モジュールに書かれている設定が尊重されます。以下は`source`フィールドでサポートされている値です。
 
-- Treat all files as source code, don't change the resolution
+- すべてのファイルをソースコードとして扱い、ソースの解決方法を変えない
 
 ```json
 {
@@ -15,7 +15,7 @@ Configuration files (such as `.babelrc`) will not be applied to files inside thi
 }
 ```
 
-- When compiling from source, use bar.js as the entry point
+- ソースからコンパイルする際に、bar.js をエントリーポイントとする
 
 ```json
 {
@@ -24,7 +24,7 @@ Configuration files (such as `.babelrc`) will not be applied to files inside thi
 }
 ```
 
-- When compiling from source, alias specific files
+- ソースからコンパイルする際に、特定のファイルにエイリアスを設定する
 
 ```json
 {
@@ -36,7 +36,7 @@ Configuration files (such as `.babelrc`) will not be applied to files inside thi
 }
 ```
 
-- When compiling from source, alias using glob patterns
+- ソースからコンパイルする際に、glob パターンを使用してエイリアスを設定する
 
 ```json
 {
@@ -47,4 +47,4 @@ Configuration files (such as `.babelrc`) will not be applied to files inside thi
 }
 ```
 
-The last example allows you to replace your entire lib directory with src so import 'my-module/lib/test.js' would resolve to 'my-module/src/test.js'. You could also use a top-level catch-all pattern like `"**": "./src/$1"` for packages like lodash that have many files in the root to replace (e.g. lodash/cloneDeep with lodash/src/cloneDeep).
+最後の例は、すべての lib ディレクトリを src に置き換えることができます、つまり 'my-module/lib/test.js' は 'my-module/src/test.js' に解決されます。また、lodash のように、ルートにたくさんの置換対象のファイルがある場合には、`"**": "./src/$1"`のように、トップレベルですべてをキャッチするパターンを使うこともできます。(例:lodash/cloneDeep から lodash/src/cloneDeep)

--- a/src/i18n/pt/docs/api.md
+++ b/src/i18n/pt/docs/api.md
@@ -18,39 +18,41 @@ const entryFiles = Path.join(__dirname, './index.html');
 
 // Opções do bundler
 const options = {
-  outDir: './dist', // O diretório de saída para construir os arquivos, dist é o padrão.
-  outFile: 'index.html', // O nome do arquivo de saída.
-  publicUrl: './', // A URL onde o servidor será servido, dist é o padrão.
+  outDir: './dist', // O diretório de saída para construir os arquivos, dist é o padrão
+  outFile: 'index.html', // O nome do arquivo de saída
+  publicUrl: './', // A URL onde o servidor será servido, dist é o padrão
   watch: true, // whether to watch the files and rebuild them on change, defaults to process.env.NODE_ENV !== 'production'
-  cache: true, // Habilita ou desabilita o cache, true é o padrão.
-  cacheDir: '.cache', // O diretório de cache a ser utilizado, .cache é o padrão.
-  contentHash: false, // Desabilita o hash de conteúdo de ser incluído no nome do arquivo.
-  minify: false, // Minifica o arquivo, habilitado se process.env.NODE_ENV === 'production'.
-  scopeHoist: false, // Torna ligado a flag de scope hoisting/tree shaking experimental, para pequenas builds de produção.
-  target: 'browser', // browser/node/electron, browser é o padrão.
+  cache: true, // Habilita ou desabilita o cache, true é o padrão
+  cacheDir: '.cache', // O diretório de cache a ser utilizado, .cache é o padrão
+  contentHash: false, // Desabilita o hash de conteúdo de ser incluído no nome do arquivo
+  global: 'moduleName', // Expor módulos como UMD utilizando este nome, desativado por padrão
+  minify: false, // Minifica o arquivo, habilitado se process.env.NODE_ENV === 'production'
+  scopeHoist: false, // Torna ligado a flag de scope hoisting/tree shaking experimental, para pequenas builds de produção
+  target: 'browser', // browser/node/electron, browser é o padrão
+  bundleNodeModules: false, // Por padrão, as dependências do package.json não são incluídas ao usar a opção 'node' ou 'electron' na opção 'target' acima. Defina como true para adicioná-los ao bundle, false é o padrão
   https: { // Define um par costumizado de {chave, certificado}, use true para gerar um ou false para utilizar http.
     cert: './ssl/c.crt', // caminho para um certificado customizado.
-    key: './ssl/k.key' // caminho para uma chave customizada.
+    key: './ssl/k.key' // caminho para uma chave customizada
   },
-  logLevel: 3, // 3 = irá loggar tudo, 2 = irá loggar avisos e erros, 1 = irá loggar erros.
-  hmr: true, // Habilita ou desabilita o HMR enquanto "watching" está ativo.
-  hmrPort: 0, // A porta onde o socket HMR está rodando, o padrão é uma porta livre aleatória (0 no node.js resolve para uma porta livre).
-  sourceMaps: true, // Habilita ou desabilita sourcemaps, habilitado é o padrão (builds minificadas atualmente sempre criam sourcemaps).
-  hmrHostname: '', // Um hostname para hot module reload, "" é o padrão.
-  detailedReport: false // Exibe um report detalhado dos bundles, assets, tamanho de arquivos e tempos, false é o padrão, os reports são exibidos somente se o watch estiver desabilidado.
+  logLevel: 3, // 3 = irá loggar tudo, 2 = irá loggar avisos e erros, 1 = irá loggar erros
+  hmr: true, // Habilita ou desabilita o HMR enquanto "watching" está ativo
+  hmrPort: 0, // A porta onde o socket HMR está rodando, o padrão é uma porta livre aleatória (0 no node.js resolve para uma porta livre)
+  sourceMaps: true, // Habilita ou desabilita sourcemaps, habilitado é o padrão (builds minificadas atualmente sempre criam sourcemaps)
+  hmrHostname: '', // Um hostname para hot module reload, "" é o padrão
+  detailedReport: false // Exibe um report detalhado dos bundles, assets, tamanho de arquivos e tempos, false é o padrão, os reports são exibidos somente se o watch estiver desabilidado
 };
 
-async function runBundle() {
+(async function() {
   // Inicializa o bundler utilizando a localização do entrypoint e as configurações especificadas.
   const bundler = new Bundler(entryFiles, options);
 
   // Executa o bundler, isto retorna o bundle principal
   // Utiliza os eventos, se você estiver com o modo watch essa promise será disparada uma única vez e não a cada rebuild
   const bundle = await bundler.bundle();
-}
-
-runBundle();
+})();
 ```
+
+Se você quiser user/iniciar o servidor built-in de desenvolvimento do Parcel, você pode utilizar `bundler.serve()`. Isso chama `bundler.bundle()` e inicia um servidor http (ou https) simples. `serve()` recebe 3 argumentos (todos eles opcionais), o primeiro é a porta, o segundo é https (isto pode ser um objeto `{cert, key}` apontando para o local da chave e arquivo do certificado ou `true` para gerar uma chave) e o terceiro é o host. 
 
 ### Eventos
 

--- a/src/i18n/pt/docs/api.md
+++ b/src/i18n/pt/docs/api.md
@@ -34,7 +34,7 @@ const options = {
     cert: './ssl/c.crt', // caminho para um certificado customizado.
     key: './ssl/k.key' // caminho para uma chave customizada
   },
-  logLevel: 3, // 3 = irá loggar tudo, 2 = irá loggar avisos e erros, 1 = irá loggar erros
+  logLevel: 3, // 5 = irá salvar tudo em um arquivo, 4 = assim como o 3 mas com timestamp e adicionalmente irá logar as requisições http realizadas para o servidor, 3 = irá loggar tudo, 2 = irá loggar avisos e erros, 1 = irá loggar erros
   hmr: true, // Habilita ou desabilita o HMR enquanto "watching" está ativo
   hmrPort: 0, // A porta onde o socket HMR está rodando, o padrão é uma porta livre aleatória (0 no node.js resolve para uma porta livre)
   sourceMaps: true, // Habilita ou desabilita sourcemaps, habilitado é o padrão (builds minificadas atualmente sempre criam sourcemaps)

--- a/src/i18n/pt/docs/cli.md
+++ b/src/i18n/pt/docs/cli.md
@@ -10,6 +10,16 @@ Inicia um servidor de desenvolvimento, que recriará automaticamente seu aplicat
 parcel index.html
 ```
 
+Você também pode passar um [glob](https://github.com/isaacs/node-glob) ou uma lista de globs para múltiplos arquivos de entrada.
+
+```bash
+parcel one.html two.html
+# OU
+parcel *.html
+# OU
+parcel ./**/*.html
+```
+
 ### Construir
 
 Constrói os recursos uma vez, ele também habilita minificação e define a variável de ambiente `NODE_ENV=production`. Veja [Produção](production.html) para mais detalhes.
@@ -17,6 +27,14 @@ Constrói os recursos uma vez, ele também habilita minificação e define a var
 ```bash
 parcel build index.html
 ```
+
+_NOTA:_ Para casos de uso especiais, é possível realizar um único build do ambiente de `development`, dessa forma:
+
+```
+NODE_ENV=development parcel build <entrypoint> --no-minify
+```
+
+Isto irá criar os mesmos bundles e então serví-los, mas não irá assistir ou servir os recursos.
 
 ### _Watch_
 
@@ -228,6 +246,16 @@ Disponível em: `serve`, `watch`, `build`
 
 ```bash
 parcel build entry.js --no-source-maps
+```
+
+### Desabilitar hashing de conteúdo
+
+Padrão: content-hash habilitado
+
+Disponível em: `build`
+
+```bash
+parcel build entry.js --no-content-hash
 ```
 
 ### Desabilitar autoinstall

--- a/src/i18n/pt/docs/cli.md
+++ b/src/i18n/pt/docs/cli.md
@@ -143,6 +143,8 @@ parcel entry.js --log-level 1
 | 1     | Somente erros  |
 | 2     | Erros e Avisos |
 | 3     | Tudo           |
+| 4     | Verboso (irá manter tudo logado com timestamps <br> e também irá logar requisições http realizadas ao servidor de desenvolvimento) |
+| 5     | Debug (irá salvar tudo em um arquivo com timestamps) |
 
 ### Hostname HMR
 

--- a/src/i18n/pt/docs/code_splitting.md
+++ b/src/i18n/pt/docs/code_splitting.md
@@ -4,6 +4,8 @@ Parcel suporta separação do código sem nenhuma configuração, de fábrica. I
 
 A separação do código é controlada pelo uso da função dinâmica `import ()` [syntax proposal](https://github.com/tc39/proposal-dynamic-import), que funciona como a declaração de `import` ou a função `require`, mas retorna uma Promise. Isso significa que o módulo é carregado de forma assíncrona.
 
+## Utilizando imports dinâmicos
+
 O exemplo a seguir mostra como você pode usar as importações dinâmicas para carregar outra página da sua aplicação sob demanda.
 
 ```javascript
@@ -19,6 +21,8 @@ import('./pages/about').then(function(page) {
   page.render()
 })
 ```
+
+## Imports dinâmicos com async/await
 
 Como `import ()` retorna uma Promise, você também pode usar async/await. Provavelmente você precisará configurar o Babel para converter a sintaxe até que ela seja suportada por todos os navegadores.
 
@@ -57,3 +61,11 @@ import './app'
 ```
 
 Leia a documentação em [babel-polyfill](http://babeljs.io/docs/usage/polyfill) e [babel-runtime](http://babeljs.io/docs/plugins/transform-runtime).
+
+## Resolução do Bundle
+
+O Parcel infere a localização dos bundles automaticamente. Isto é feito pelo módulo [bundle-url](https://github.com/parcel-bundler/parcel/blob/master/packages/core/parcel-bundler/src/builtins/bundle-url.js) e utiliza o rastreamento de pilha para determinar o caminho onde o pacote inicial foi carregado.
+
+Isso significa que você não precisa configurar onde os bundles devem ser carregados, mas também significa que você deve servir os bundles do mesmo local.
+
+O pacote resolve atualmente pacotes nos seguintes protocolos: `http`, `https`, `file`, `ftp`, `chrome-extension` e `moz-extension`.

--- a/src/i18n/pt/docs/coffeeScript.md
+++ b/src/i18n/pt/docs/coffeeScript.md
@@ -1,3 +1,15 @@
 # CoffeeScript
 
 _Extensões suportadas: `coffee`_
+
+[CoffeeScript](https://coffeescript.org) é uma linguagem que transpila para Javascript e permite que você use uma sintaxe mais curta e outros recursos como o [operador existencial](https://coffeescript.org/#existential-operator), [sintaxe curta array-splicing](https://coffeescript.org/#slices), [blocos de expressões regulares](https://coffeescript.org/#regexes) e mais.
+
+```coffeescript
+# log.coffee
+console.log 'Hello there!'
+```
+
+```javascript
+// index.js
+import './log'
+```

--- a/src/i18n/pt/docs/css.md
+++ b/src/i18n/pt/docs/css.md
@@ -2,7 +2,17 @@
 
 _Extensões suportadas: `css`, `pcss`, `postcss`_
 
-Recursos CSS podem ser importados de um arquivo Javascript ou HTML, e podem conter dependências referenciadas pela sintaxe `@import`, bem como referências a imagens, fontes, etc. através da função `url()`. Outros arquivos CSS que são `@import`ados de forma _inline_ no mesmo pacote CSS e referenciadas com `url()` serão reescritas em seus nomes de arquivos de saída. Todos os nomes de arquivos devem ser relativos ao arquivo CSS atual.
+Recursos CSS podem ser importados de um arquivo Javascript ou HTML:
+
+```js
+import './index.css';
+```
+
+```html
+<link rel="stylesheet" type="text/css" href="index.css">
+```
+
+Recursos CSS podem conter dependências referenciadas pela sintaxe `@import`, bem como referências a imagens, fontes, etc. através da função `url()`. Outros arquivos CSS que são `@import`ados de forma _inline_ no mesmo pacote CSS e referenciadas com `url()` serão reescritas em seus nomes de arquivos de saída. Todos os nomes de arquivos devem ser relativos ao arquivo CSS atual.
 
 ```css
 /* Importando outro arquivo CSS */
@@ -16,7 +26,7 @@ Recursos CSS podem ser importados de um arquivo Javascript ou HTML, e podem cont
 
 Além de CSS simples, outras linguagens que compilam para CSS como LESS, SASS e Stylus também são suportadas, e funcionam da mesma maneira.
 
-# PostCSS
+## PostCSS
 
 [PostCSS](http://postcss.org) é uma ferramenta pra transformar CSS com plugins, como o [autoprefixer](https://github.com/postcss/autoprefixer), [Preset Env](https://github.com/csstools/postcss-preset-env), e [CSS Modules](https://github.com/css-modules/css-modules). Você pode configurar o PostCSS com o Parcel ao criar um arquivo de configuração com um desses nomes: `.postcssrc` (JSON), `.postcssrc.js`, ou `postcss.config.js`.
 
@@ -50,11 +60,11 @@ last 2 versions
 
 Os módulos CSS são ativados de forma ligeiramente diferente usando a chave `módulos` no nível superior. Isso é porque Parcel precisa ter suporte especial para módulos CSS, uma vez que é exportado um objeto a ser incluído no pacote JavaScript também. Note que você ainda precisa instalar o `postcss-modules` em seu projeto.
 
-## Uso com bibliotecas CSS existentes
+### Uso com bibliotecas CSS existentes
 
 Para que os módulos CSS funcionem corretamente com os módulos existentes, eles precisam especificar esse suporte em seus próprios `.postcssrc`.
 
-## Definindo a configuração de Minificação do cssnano
+### Definindo a configuração de Minificação do cssnano
 
 Parcel adiciona o [cssnano](http://cssnano.co) ao postcss para minificar o css em _build_ de produção, onde configurações customizadas podem ser definidas ao criar o arquivo `cssnano.config.js`:
 

--- a/src/i18n/pt/docs/elm.md
+++ b/src/i18n/pt/docs/elm.md
@@ -2,7 +2,7 @@
 
 _Extensões suportadas: `elm`_
 
-[Elm](https://elm-lang.org/) é uma linguagem funcional com um sistema de tipos avançados que garantem a correção do seu código e evita erros confusos em tempo de execução. Com o seu foco na simplicidade e velocidade, Elm é uma ótima opção quando se trata de construção de webapps de todos os tipos. O Parcel tem suport nativo ao Elm sem a necessidade de nenhuma configuração adicional.
+[Elm](https://elm-lang.org/) é uma linguagem funcional com um sistema de tipos avançados que garantem a correção do seu código e evita erros confusos em tempo de execução. Com o seu foco na simplicidade e velocidade, Elm é uma ótima opção quando se trata de construção de webapps de todos os tipos. O Parcel tem suporte nativo ao Elm sem a necessidade de nenhuma configuração adicional.
 
 ```html
 <!-- index.html -->

--- a/src/i18n/pt/docs/elm.md
+++ b/src/i18n/pt/docs/elm.md
@@ -1,0 +1,39 @@
+# Elm
+
+_Extensões suportadas: `elm`_
+
+[Elm](https://elm-lang.org/) é uma linguagem funcional com um sistema de tipos avançados que garantem a correção do seu código e evita erros confusos em tempo de execução. Com o seu foco na simplicidade e velocidade, Elm é uma ótima opção quando se trata de construção de webapps de todos os tipos. O Parcel tem suport nativo ao Elm sem a necessidade de nenhuma configuração adicional.
+
+```html
+<!-- index.html -->
+
+<html>
+  <body>
+    <main></main>
+    <script src="./index.js"></script>
+  </body>
+</html>
+```
+
+```javascript
+// index.js
+
+import { Elm } from './Main.elm'
+
+Elm.Main.init({
+  node: document.querySelector('main')
+})
+```
+
+```elm
+-- Main.elm
+module Main exposing (main)
+
+import Browser
+import Html exposing (h1, text)
+
+main =
+  h1 [] [ text "Hello, Elm!" ]
+```
+
+Para saber mais sobre o Elm e seu ecossistema de ferramentas, consulte o [guia oficial](https://guide.elm-lang.org/).

--- a/src/i18n/pt/docs/getting_started.md
+++ b/src/i18n/pt/docs/getting_started.md
@@ -58,7 +58,7 @@ Utilize o servidor de desenvolvimento caso você não tenha seu próprio servido
 parcel watch index.html
 ```
 
-### Mútiplos arquivos de entrada
+## Mútiplos arquivos de entrada
 
 No caso de você ter mais de um arquivo de entrada, vamos dizer `index.html` e `about.html`, você tem duas maneiras de executar o bundler:
 
@@ -85,6 +85,47 @@ _NOTA:_ No caso de você possuir uma estrutura de arquivos como esta:
 
 Acessar http://localhost:1234/diretorio-1/ não irá funcionar, você terá que apontar explicitamente para o arquivo http://localhost:1234/diretorio-1/index.html.
 
-### Construindo para Produção
+## Construindo para Produção
 
 Quando você estiver pronto para enviar sua aplicação para produção, o modo `build` desativa a opção `watch` e constrói seus arquivos uma única vez. Veja a seção [Produção](production.html) para mais detalhes.
+
+## Adicionando Parcel ao seu projeto
+
+Às vezes, não é possível instalar o Parcel globalmente, por exemplo, se você estiver construindo no agente de compilação de outra pessoa ou quiser usar um CI para criar seu projeto programaticamente. Nesse caso, você pode instalar e executar o Parcel como um pacote local.
+
+Para instalar com Yarn:
+
+```bash
+yarn add parcel-bundler --dev
+```
+
+Para instalar com NPM:
+
+```bash
+npm install parcel-bundler --save-dev
+```
+
+Então, adicione esses scripts de tarefas para o seu projeto, modificando o seu `package.json`:
+
+```json
+{
+  "scripts": {
+    "dev": "parcel <your entry file>",
+    "build": "parcel build <your entry file>"
+  }
+}
+```
+
+Então, você será capaz de executá-lo:
+
+```bash
+# Para executar em modo de desenvolvimento
+yarn dev
+# ou
+npm run dev
+
+# Para executar em modo de produção
+yarn build
+# ou
+npm run build
+```

--- a/src/i18n/pt/docs/javascript.md
+++ b/src/i18n/pt/docs/javascript.md
@@ -2,7 +2,7 @@
 
 _Extensões suportadas: `js`, `jsx`, `es6`, `jsm`, `mjs`_
 
-O tipo de arquivo mais utilizado pelos empacotadores é o JavaScript. Parcel suporta tanto CommonJS como módulos ES6 para importar os arquivos. Ele também suporta a função `import()` para carregar os módulos de forma assíncrona, o qual será discutido na sessão [separação do código](code_splitting.html).
+O tipo de arquivo mais utilizado pelos empacotadores é o JavaScript. Parcel suporta tanto CommonJS como módulos ES6 para importar os arquivos. Ele também suporta a função `import()` para carregar os módulos de forma assíncrona, o qual será discutido na sessão [separação do código](code_splitting.html). Importações dinâmicas também podem importar módulos de URLs.
 
 ```javascript
 // Importar um módulo utilizando sintaxe CommonJS
@@ -10,6 +10,11 @@ const dep = require('./path/to/dep')
 
 // Importar um módulo utilizando sintaxe ES6
 import dep from './path/to/dep'
+
+// Importando um módulo de uma URL (por exemplo, um CDN) usando importação dinâmica
+import('https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.11/lodash.min.js').then(() => {
+  console.log(_.VERSION);
+});
 ```
 
 Você também pode importar outros tipos de recursos que não sejam arquivos JavaScript, como um arquivo CSS ou mesmo uma imagem. Quando você importar um desses tipos de arquivos, eles não serão incluídos no arquivo principal assim como é feito com os outros empacotadores. Na verdade, eles serão adicionados em arquivos separados (por exemplo, um arquivo CSS) junto com suas dependências. Quando você utilizar [CSS Modules](https://github.com/css-modules/css-modules), as classes exportadas são adicionadas no arquivo de saída JavaScript. Outros tipos de recursos exportam a referência no arquivo de saída JavaScript para que você possa referenciar no seu código.
@@ -47,7 +52,7 @@ const buffer = fs.readFileSync(__dirname + '/test.png')
 ;<img src={`data:image/png;base64,${buffer.toString('base64')}`} />
 ```
 
-### Imagens em JSX
+## Imagens em JSX
 
 Abaixo há um exemplo de como importar imagens para utilizar com JSX.
 
@@ -62,23 +67,33 @@ import megaMan from "./images/mega-man.png";
 <img src={`/dist${megaMan}`} title="Mega Man" alt="Mega Man" />
 ```
 
-# Babel
+## Babel
 
 [Babel](https://babeljs.io) é o conversor de JavaScript mais popular que conta com um grande ecossistema de plugins. Usar o Babel com o Parcel funciona da mesma maneira que utilizá-lo sozinho ou com outros empacotadores.
 
 Instale as predefinições e plugins na sua aplicação:
 
 ```shell
-yarn add @babel/preset-env
+yarn add --dev @babel/preset-react
 ```
 
 Crie o arquivo `.babelrc`:
 
 ```json
 {
-  "presets": ["@babel/preset-env"]
+  "presets": ["@babel/preset-react"]
 }
 ```
+
+Você também pode colocar a configuração `babel` no `package.json`
+
+```json
+"babel": {
+  "presets": ["@babel/preset-react"]
+}
+```
+
+NOTA: `package.json` tem precedência sobre o  `.babelrc`.
 
 ## Conversões padrões do Babel
 
@@ -90,7 +105,7 @@ O alvo padrão do _browserlist_ é: `> 0.25%` (Significando, suportar cada naveg
 
 Para o alvo `node`, Parcel utiliza o `engines.node` definido no `package.json`, este padrão para _node 8_.
 
-# Flow
+## Flow
 
 [Flow](https://flow.org/) é um popular checador de tipo para JavaScript. Usar Flow com Parcel é muito simples, basta inserir `// @flow` na primeira linha dos arquivos `js`.
 

--- a/src/i18n/pt/docs/module_resolution.md
+++ b/src/i18n/pt/docs/module_resolution.md
@@ -65,7 +65,7 @@ Evite utilizar quaisquer caracteres especiais em seus acrônimos, alguns podem s
 
 Recomendamos ser explícito ao definir seus acrônimos, então por favor **especifique extensões**, caso contrário o Parcel terá de adivinhar. Consulte [exportações denominadas com Javascript](#exportações-denominadas-com-javascript) para um exemplo disso.
 
-## Outras Condições
+## Problemas comuns
 
 ### Exportações denominadas com Javascript
 

--- a/src/i18n/pt/docs/module_resolution.md
+++ b/src/i18n/pt/docs/module_resolution.md
@@ -1,21 +1,43 @@
 # 📔 Resolução de Módulo
 
-Parcel (v.1.7.0 e superior) suporta estratégias de múltilplas resoluções de módulo fora da caixa, para que você não tenha que lidar com caminhos relativos infinitos `../../`.
+O resolvedor do Parcel implementa uma versão modificada do algoritmo de [resolução do node_modules](https://nodejs.org/api/modules.html#modules_all_together).
 
-Termos Notáveis:
+## Resolução de Módulo
 
-- **raiz do projeto**: o diretório do _entrypoint_ especificado para o Parcel, ou a raiz compartilhada (diretório pai em comum) quando múltiplos _entrypoints_ são especificados.
+Além do algorimo padrão, todos os [tipos de recursos suportados pelo Parcel](https://parceljs.org/assets.html) são resolvidos também.
+
+A resolução de módulo pode ser relativa a:
+
+- **raiz do projeto**: o diretório do *entrypoint* especificado para o Parcel, ou a raiz compartilhada (diretório pai em comum) quando múltiplos _entrypoints_ são especificados.
 - **raiz do pacote**: o diretório mais próximo da raiz do pacote em `node_modules`.
 
-## Caminhos Absolutos
+### Caminhos Absolutos
 
 `/foo` irá resolver `foo` relativo à **raiz do projeto**.
 
-## ~ Caminhos com til
+### ~ Caminhos com til
 
 `~/foo` irá resolver `foo` em relação à **raiz do pacote** mais próxima ou, se não for encontrada, a **raiz do projeto**.
 
-## Acrônimos
+### Caminho de arquivos Glob
+
+Globs são importações curingas que agrupam vários recursos de uma só vez. Globs podem combinar alguns ou todos os arquivos (`/assets/*.png`), bem como arquivos em vários diretórios (`/assets/**/*`)
+
+Este exemplo empacota um diretório de arquivos png e retorna as URLs de produção.
+
+```javascript
+import foo from "/assets/*.png";
+// {
+//   'file-1': '/file-1.8e73c985.png',
+//   'file-2': '/file-1.8e73c985.png'
+// }
+```
+
+### Campo `browser` no package.json
+
+Se um pacote incluir o [campo `package.browser`](https://docs.npmjs.com/files/package.json#browser), o Parcel irá utilizá-lo ao invés da entrada `package.main`.
+
+### Acrônimos
 
 Os acrônimos são suportados através do campo `alias` no `package.json`.
 
@@ -75,15 +97,19 @@ Flow precisará saber sobre a resolução de módulos para o uso de caminhos abs
 Dado um projeto com essa estrutura:
 
 ```
+package.json
 .flowconfig
 src/
+  index.html
   index.js
   components/
     apple.js
     banana.js
 ```
 
-Para mapear corretamente
+E `src/index.html` como um *entrypoint*, a **raíz do projeto** (*project root*) é o diretório `src/`.
+
+Portanto, para mapear essa importação corretamente:
 
 ```javascript
 // index.js

--- a/src/i18n/pt/docs/module_resolution.md
+++ b/src/i18n/pt/docs/module_resolution.md
@@ -120,7 +120,7 @@ import Apple from '/components/apple'
 
 nós podemos usar essa configuração no arquivo `.flowconfig` para mapear o caminho absoluto (o direcionamento de `/`) para `src/`:
 
-```
+```ini
 [options]
 module.name_mapper='^\/\(.*\)$' -> '<PROJECT_ROOT>/src/\1'
 ```

--- a/src/i18n/pt/docs/pug.md
+++ b/src/i18n/pt/docs/pug.md
@@ -1,3 +1,143 @@
 # Pug
 
 _Extensões suportadas: `jade`, `pug`_
+
+Preparar o Pug é fácil. Você pode ter qualquer estrutura de arquivo, aqui é fornecido vários exemplos simples como um ponto de referência.
+
+## Exemplo 1 - Apenas index.pug
+
+Vamos assumir esta estrutura de arquivos:
+
+```bash
+.
+├── package.json
+└── src
+    └── index.pug
+```
+
+Nós podemos ter isso em execução utilizando este comando do Parcel: `parcel src/index.pug`.
+
+## Exemplo 2 - index.pug, index.js and style.css
+
+Vamos assumir esta estrutura de arquivos:
+
+```bash
+.
+├── package.json
+└── src
+    ├── index.js
+    ├── index.pug
+    └── style.css
+```
+
+Dentro do index.pug, apenas carregue as folhas de estilos e o JS como de costume.
+
+```pug
+// index.pug
+
+doctype html
+html(lang="")
+  head
+    // ...
+    link(rel="stylesheet", href="index.css")
+  body
+    h1 Hello
+
+    script(src="index.js")
+```
+
+Se estiver utilizando Stylys, Sass ou LESS, você pode executar da mesma forma. Se preferir, você pode importar seu arquivo de estilo diretamente em seu arquivo JS.
+
+Nós podemos ter isso em execução utilizando este comando do Parcel: `parcel src/index.pug`.
+
+## Exemplo 3 - Pug with locals
+
+Vamos assumir esta estrutura de arquivos:
+
+```bash
+.
+├── package.json
+└── src
+    ├── index.pug
+    └── pug.config.js
+```
+
+Nós precisamos exportar um objeto `locals` de um arquivo `pug.config.js`. O arquivo `pug.config.js` precisa estar no diretório do arquivo `index.pug` OU, em um diretório contendndo o arquivo `package.json`. O arquivo `pug.config.js` não precisa ser importado dentro de um arquivo js explicitamente. Esta **É** única maneira de ter um objeto `locals` disponível para seus templates Pug.
+
+```js
+// pug.config.js
+
+module.exports = {
+  locals: {
+    hello: "world"
+  }
+};
+```
+
+```pug
+// index.pug
+
+doctype html
+html(lang="")
+  head
+    // ...
+  body
+    h1 #{hello}
+```
+
+Nós podemos ter isso em execução utilizando este comando do Parcel: `parcel src/index.pug`.
+
+### Cancelar e executar novamente o pacote após a atualização de objetos locais
+
+Você não será capaz de ver as alterações feitas no seu objeto `locals` em tempo real. Se você atualizar o seu objeto `locals`, você precisará cancelar o processo do Parcel em seu terminal e executar novamente `parcel src/index.pug`.
+
+### Veja nossos erros silenciosos
+
+Além disso, entenda que se você usar essa instalação locals, você não receberá um erro se você usar uma propriedade que não existe para interpolação no seu Pug. Assim, se escrevemos `h1 #{thing}` e não havia nenhuma propriedade `thing` em locals, então o Parcel não vai falhar, nem relatar um erro. Você só será deixado com um resultado vazio no navegador. Portanto, tenha cuidado para obter esse direito, ou você pode não saber que um elemento interpolado não está funcionando.
+
+### Apenas três opções de nomeação de arquivo
+
+Você pode usar um arquivo `.pugrc` ou `.pugrc.js` em vez de `pug.config.js`. Mas estas são as únicas 3 variações que funcionarão para a criação de locals.
+
+### Não é possível usar instruções de importação no arquivo `pug.config.js`
+
+Se você quiser importar outros arquivos para o arquivo `pug.config.js` você deve usar instruções require.
+
+Isto irá funcionar:
+
+```js
+// pug.config.js
+
+const data = require("./data.js");
+
+module.exports = {
+  locals: {
+    d: data
+  }
+};
+
+```
+
+Isto NÃO irá funcionar:
+
+```js
+import data from "./data.js";
+
+module.exports = {
+  locals: {
+    d: data
+  }
+};
+```
+
+## Adicionando um script ao package.json
+
+```json
+"scripts": {
+    "dev": "parcel src/index.pug",
+    "devopen": "parcel src/index.pug --open 'google chrome'",
+    "build": "parcel build src/index.pug"
+  },
+```
+
+Nós podemos executar `npm run dev` ou `npm run devopen` para ter o projeto aberto no navegador. Nós podemos construir o projeto para produção com  `npm run build`.

--- a/src/i18n/pt/docs/stylus.md
+++ b/src/i18n/pt/docs/stylus.md
@@ -1,3 +1,17 @@
 # Stylus
 
 _Extensões suportadas: `stylus`_
+
+Não é necessário instalar o Stylus 😱, o Parcel irá instalá-lo automaticamente quando detectar um arquivo do Stylus.
+
+Você pode importar arquivos Stylus a partir de arquivos Javascript ou html.
+
+```javascript
+import './custom.styl'
+```
+
+or
+
+```html
+<link href="./custom.styl" rel="stylesheet">
+```

--- a/src/i18n/pt/docs/typeScript.md
+++ b/src/i18n/pt/docs/typeScript.md
@@ -23,3 +23,47 @@ console.log(message)
 // message.ts
 export default 'Hello, world'
 ```
+
+## Quando utilizado com React
+
+Para utilizar Typescript + React + JSX, você precisa
+
+1. utilizar a extensão `.tsx`
+2. requerer o React corretamente
+3. usar tsconfig com uma [opção especial](https://www.typescriptlang.org/docs/handbook/jsx.html) `"jsx": "react"`
+
+Exemplo completo:
+
+```html
+<!-- index.html -->
+<html>
+<body>
+  <div id="root"></div>
+  <script src="./index.tsx"></script>
+</body>
+</html>
+```
+
+```typescript
+// index.tsx
+import React from 'react'
+import ReactDOM from 'react-dom'
+
+console.log('Hello from tsx!')
+
+ReactDOM.render(
+  <p>Hello</p>,
+  document.getElementById('root'),
+)
+```
+
+```json
+// tsconfig.json
+{
+  "compilerOptions": {
+    "jsx": "react"
+  }
+}
+```
+
+Veja [este tópico completo](https://github.com/parcel-bundler/parcel/issues/1199) para maiores detalhes.

--- a/src/i18n/pt/docs/vue.md
+++ b/src/i18n/pt/docs/vue.md
@@ -1,3 +1,54 @@
 # Vue
 
 _Extensões suportadas: `vue`_
+Vue.js é um progressivo e incrementalmente adoptável framework Javascript para criar UI na Web. O Parcel tem suporte nativo ao Vue sem a necessidade de nenhuma configuração adicional.
+
+```html
+<!-- index.html -->
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Parcel - Vue</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script src="./index.js"></script>
+  </body>
+</html>
+
+```
+
+Você pode usar todas as ferramentas como (Pug, TypeScript, SCSS, ...):
+
+```vue
+// app.vue
+<template lang="pug">
+  .container Hello {{bundler}}
+</template>
+
+<script lang="ts">
+import Vue from "vue";
+export default Vue.extend({
+  data() {
+    return {
+      bundler: "Parcel"
+    };
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.container {
+  color: green;
+}
+</style>
+
+```
+
+```js
+// index.js
+import Vue from 'vue';
+import App from './app.vue';
+
+new Vue(App).$mount('#app')
+```

--- a/src/i18n/pt/layout/page.html
+++ b/src/i18n/pt/layout/page.html
@@ -120,6 +120,9 @@
             <a href="webAssembly.html"><img src="assets/icon-webassembly.svg" />WebAssembly</a>
           </li>
           <li>
+            <a href="elm.html"><img src="assets/icon-elm.svg" />Elm</a>
+          </li>
+          <li>
             <a href="yaml.html"><img src="assets/icon-yaml.svg" />YAML</a>
           </li>
           <li>


### PR DESCRIPTION
Sending some changes to synchronize the documentation in portuguese with that which is available in english. 📝 While I did this, I also altered some simple things in the markdown of the documentation files in english. Things like spacing, correct use of  "#" for titles, adding syntax in code blocks, etc.