### PR TITLE
Trivial: make usage of `--dev` flag consistent

### DIFF
--- a/src/i18n/en/docs/recipes.md
+++ b/src/i18n/en/docs/recipes.md
@@ -106,7 +106,7 @@ npm install --save-dev parcel-bundler
 <sub>Or if you have the optional Yarn package manager installed</sub>
 
 ```bash
-yarn add typescript --dev
+yarn add --dev typescript
 yarn add --dev parcel-bundler
 ```
 


### PR DESCRIPTION
Consistency makes things easier to read. This is trivial but (I hope) a no brainer.

NB. Related, it's worth noting that the [yarn docs](https://yarnpkg.com/lang/en/docs/cli/add/) actually show the --flags at the end of the command, so maybe this usage is (consistently) wrong?