### PR TITLE
Update Preact section in recipes.md

### DIFF
--- a/src/i18n/en/docs/recipes.md
+++ b/src/i18n/en/docs/recipes.md
@@ -35,33 +35,14 @@ First we need to install the dependencies for Preact.
 
 ```bash
 npm install --save preact
-npm install --save preact-compat
 npm install --save-dev parcel-bundler
-npm install --save-dev babel-core
-npm install --save-dev babel-preset-preact
 ```
 
 <sub>Or if you have the optional Yarn package manager installed</sub>
 
 ```bash
 yarn add preact
-yarn add preact-compat
 yarn add --dev parcel-bundler
-yarn add --dev babel-core
-yarn add --dev babel-preset-preact
-```
-
-You should manually add [babel-core](https://www.npmjs.com/package/babel-core) for [babel-preset-preact](https://github.com/developit/babel-preset-preact) has not supported babel7 yet
-
-Then make sure the following Babel config is present.
-
-```javascript
-// .babelrc
-{
-  "presets": [
-    "preact"
-  ]
-}
 ```
 
 Add Start script to `package.json`

--- a/src/i18n/es/docs/recipes.md
+++ b/src/i18n/es/docs/recipes.md
@@ -48,29 +48,14 @@ Primero necesitas instalar las dependencias para Preact.
 
 ```
 npm install --save preact
-npm install --save preact-compat
 npm install --save-dev parcel-bundler
-npm install --save-dev babel-preset-env
-npm install --save-dev babel-preset-preact
 ```
 
 <sub>O, si opcionalmente tienes instalado Yarn como gestor de paquetes</sub>
 
 ```
 yarn add preact
-yarn add preact-compat
 yarn add --dev parcel-bundler
-yarn add --dev babel-preset-env
-yarn add --dev babel-preset-preact
-```
-
-Luego, asegúrate que la siguiente configuración de Babel esté presente.
-
-```javascript
-// .babelrc
-{
-  "presets": ["env", "preact"]
-}
 ```
 
 Agrega el script de inicio a `package.json`

--- a/src/i18n/fr/docs/recipes.md
+++ b/src/i18n/fr/docs/recipes.md
@@ -35,29 +35,14 @@ D'abord vous avez besoin d'installer les dépendances pour Preact.
 
 ```bash
 npm install --save preact
-npm install --save preact-compat
 npm install --save-dev parcel-bundler
-npm install --save-dev babel-preset-preact
 ```
 
 <sub>Ou si vous avez installé le gestionnaire de paquets Yarn</sub>
 
 ```bash
 yarn add preact
-yarn add preact-compat
 yarn add --dev parcel-bundler
-yarn add --dev babel-preset-preact
-```
-
-Ensuite, assurez-vous que la configuration Babel suivante est présente.
-
-```javascript
-// .babelrc
-{
-  "presets": [
-    "preact"
- ]
-}
 ```
 
 Ajoutez un script de démarrage à `package.json`

--- a/src/i18n/it/docs/recipes.md
+++ b/src/i18n/it/docs/recipes.md
@@ -35,29 +35,14 @@ Come prima cosa installa le dipendenze di Preact
 
 ```bash
 npm install --save preact
-npm install --save preact-compat
 npm install --save-dev parcel-bundler
-npm install --save-dev babel-preset-env
-npm install --save-dev babel-preset-preact
 ```
 
 <sub>Oppure, se si vuole utilizzare Yarn</sub>
 
 ```bash
 yarn add preact
-yarn add preact-compat
 yarn add --dev parcel-bundler
-yarn add --dev babel-preset-env
-yarn add --dev babel-preset-preact
-```
-
-Poi assicurati che questa configurazione di Babel sia presente.
-
-```javascript
-// .babelrc
-{
-  "presets": ["env", "preact"]
-}
 ```
 
 Aggiungi uno script di Start nel `package.json`

--- a/src/i18n/ja/docs/recipes.md
+++ b/src/i18n/ja/docs/recipes.md
@@ -35,29 +35,14 @@ First we need to install the dependencies for Preact.
 
 ```bash
 npm install --save preact
-npm install --save preact-compat
 npm install --save-dev parcel-bundler
-npm install --save-dev babel-preset-preact
 ```
 
 <sub>Or if you have the optional Yarn package manager installed</sub>
 
 ```bash
 yarn add preact
-yarn add preact-compat
 yarn add --dev parcel-bundler
-yarn add --dev babel-preset-preact
-```
-
-Then make sure the following Babel config is present.
-
-```javascript
-// .babelrc
-{
-  "presets": [
-    "preact"
-  ]
-}
 ```
 
 Add Start script to `package.json`

--- a/src/i18n/ko/docs/recipes.md
+++ b/src/i18n/ko/docs/recipes.md
@@ -35,29 +35,14 @@ yarn add --dev parcel-bundler
 
 ```bash
 npm install --save preact
-npm install --save preact-compat
 npm install --save-dev parcel-bundler
-npm install --save-dev babel-preset-env
-npm install --save-dev babel-preset-preact
 ```
 
 <sub>혹시 yarn 패키지 매니저를 사용하신다면 다음의 명령어로 설치할 수 있습니다.</sub>
 
 ```bash
 yarn add preact
-yarn add preact-compat
 yarn add --dev parcel-bundler
-yarn add --dev babel-preset-env
-yarn add --dev babel-preset-preact
-```
-
-그리고 다음과 같이 babel 설정 파일을 만들어주세요.
-
-```javascript
-// .babelrc
-{
-  "presets": ["env", "preact"]
-}
 ```
 
 그리고 시작 스크립트를 `package.json`에 지정해주세요.

--- a/src/i18n/pl/docs/recipes.md
+++ b/src/i18n/pl/docs/recipes.md
@@ -48,29 +48,14 @@ Najpierw należy zainstalować zależności potrzebne dla Preact.
 
 ```bash
 npm install --save preact
-npm install --save preact-compat
 npm install --save-dev parcel-bundler
-npm install --save-dev babel-preset-env
-npm install --save-dev babel-preset-preact
 ```
 
 <sub>Lub, jeśli używasz Yarn:</sub>
 
 ```bash
 yarn add preact
-yarn add preact-compat
 yarn add --dev parcel-bundler
-yarn add --dev babel-preset-env
-yarn add --dev babel-preset-preact
-```
-
-Następnie upewnij się, że w projekcie znajduje się poniższa konfiguracja Babel:
-
-```javascript
-// .babelrc
-{
-  "presets": ["env", "preact"]
-}
 ```
 
 Dodaj skrypt startowy do `package.json`:

--- a/src/i18n/pt/docs/recipes.md
+++ b/src/i18n/pt/docs/recipes.md
@@ -35,29 +35,14 @@ Primeiro instale as dependências do Preact.
 
 ```bash
 npm install --save preact
-npm install --save preact-compat
 npm install --save-dev parcel-bundler
-npm install --save-dev babel-preset-preact
 ```
 
 <sub>Ou se você tiver opcionalmente o gerenciador de pacotes Yarn instalado</sub>
 
 ```bash
 yarn add preact
-yarn add preact-compat
 yarn add --dev parcel-bundler
-yarn add --dev babel-preset-preact
-```
-
-Então verifique se a seguinte configuração do Babel está presente.
-
-```javascript
-// .babelrc
-{
-  "presets": [
-    "preact"
-  ]
-}
 ```
 
 Adicione o script de inicialização ao `package.json`

--- a/src/i18n/ru/docs/recipes.md
+++ b/src/i18n/ru/docs/recipes.md
@@ -39,29 +39,14 @@ yarn add --dev babel-preset-react
 
 ```bash
 npm install --save preact
-npm install --save preact-compat
 npm install --save-dev parcel-bundler
-npm install --save-dev babel-preset-env
-npm install --save-dev babel-preset-preact
 ```
 
 <sub>Или, если у вас установлен менеджер пакетов Yarn</sub>
 
 ```bash
 yarn add preact
-yarn add preact-compat
 yarn add --dev parcel-bundler
-yarn add --dev babel-preset-env
-yarn add --dev babel-preset-preact
-```
-
-Затем убедитесь, что присутствует следующая конфигурация Babel.
-
-```javascript
-// .babelrc
-{
-  "presets": ["env", "preact"]
-}
 ```
 
 Затем добавьте скрипт запуска в `package.json`

--- a/src/i18n/uk/docs/recipes.md
+++ b/src/i18n/uk/docs/recipes.md
@@ -39,29 +39,14 @@ yarn add --dev babel-preset-react
 
 ```Bash
 npm install --save preact
-npm install --save preact-compat
 npm install --save-dev parcel-bundler
-npm install --save-dev babel-preset-env
-npm install --save-dev babel-preset-preact
 ```
 
 <sub> Або, якщо у вас встановлений менеджер пакетів Yarn </sub>
 
 ```Bash
 yarn add preact
-yarn add preact-compat
 yarn add --dev parcel-bundler
-yarn add --dev babel-preset-env
-yarn add --dev babel-preset-preact
-```
-
-Потім переконайтеся, що існує така конфігурація Babel.
-
-```Javascript
-// .babelrc
-{
-  "Presets": [ "env", "preact"]
-}
 ```
 
 Потім додайте скрипт запуску в `package.json`

--- a/src/i18n/zh-tw/docs/recipes.md
+++ b/src/i18n/zh-tw/docs/recipes.md
@@ -35,29 +35,14 @@ yarn add --dev parcel-bundler
 
 ```bash
 npm install --save preact
-npm install --save preact-compat
 npm install --save-dev parcel-bundler
-npm install --save-dev babel-preset-preact
 ```
 
 <sub>或者是你想使用 Yarn 來管理套件</sub>
 
 ```bash
 yarn add preact
-yarn add preact-compat
 yarn add --dev parcel-bundler
-yarn add --dev babel-preset-preact
-```
-
-確保你的 Babel 設定如下：
-
-```javascript
-// .babelrc
-{
-  "presets": [
-    "preact"
-  ]
-}
 ```
 
 接著在 `package.json` 中增加啟動指令

--- a/src/i18n/zh/docs/recipes.md
+++ b/src/i18n/zh/docs/recipes.md
@@ -35,29 +35,14 @@ yarn add --dev parcel-bundler
 
 ```bash
 npm install --save preact
-npm install --save preact-compat
 npm install --save-dev parcel-bundler
-npm install --save-dev babel-preset-env
-npm install --save-dev babel-preset-preact
 ```
 
 <sub>或者如果说你安装了 Yarn 包管理器，作为 npm 的备选</sub>
 
 ```bash
 yarn add preact
-yarn add preact-compat
 yarn add --dev parcel-bundler
-yarn add --dev babel-preset-env
-yarn add --dev babel-preset-preact
-```
-
-然后确保以下 Babel 预设存在.
-
-```javascript
-// .babelrc
-{
-  "presets": ["env", "preact"]
-}
 ```
 
 向 `package.json` 的 scripts 中添加 start 脚本。


### PR DESCRIPTION
For Preact, installing `babel-core` and `babel-preset-preact` is unnecessary in the current version.