### PR TITLE
Add yarn instructions

### DIFF
--- a/src/i18n/en/docs/scss.md
+++ b/src/i18n/en/docs/scss.md
@@ -2,10 +2,18 @@
 
 _Supported extensions: `sass`, `scss`_
 
-SCSS compilation needs `sass` (JS version of `dart-sass`) module. To install it with npm:
+SCSS compilation needs `sass` (JS version of `dart-sass`) module. 
+
+To install it with npm:
 
 ```bash
 npm install -D sass
+```
+
+To install it with yarn:
+
+```bash
+yarn add -D sass
 ```
 
 Once you have `sass` installed you can import SCSS files from JavaScript files.


### PR DESCRIPTION
Parcel's [Getting Started documentation ](https://parceljs.org/getting_started.html) includes both yarn and npm installation instructions. 

To maintain consistency with that pattern, this update adds  yarn-specific installation instructions to the [Parcel SCSS page](https://parceljs.org/scss.html).