### PR TITLE
Improved some readability

### DIFF
--- a/src/i18n/en/docs/vue.md
+++ b/src/i18n/en/docs/vue.md
@@ -6,11 +6,14 @@ Vue.js is a progressive, incrementally-adoptable JavaScript framework for buildi
 
 ```html
 <!-- index.html -->
+
 <!DOCTYPE html>
+
 <html lang="en">
   <head>
     <title>Parcel - Vue</title>
   </head>
+  
   <body>
     <div id="app"></div>
     <script src="./index.js"></script>
@@ -22,13 +25,15 @@ Vue.js is a progressive, incrementally-adoptable JavaScript framework for buildi
 You can use all tools you like (Pug, TypeScript, SCSS, ...):
 
 ```vue
-// app.vue
+// App.vue
+
 <template lang="pug">
   .container Hello {{bundler}}
 </template>
 
 <script lang="ts">
 import Vue from "vue";
+
 export default Vue.extend({
   data() {
     return {
@@ -43,13 +48,13 @@ export default Vue.extend({
   color: green;
 }
 </style>
-
 ```
 
 ```js
 // index.js
+
 import Vue from 'vue';
-import App from './app.vue';
+import App from './App.vue';
 
 new Vue(App).$mount('#app')
 ```


### PR DESCRIPTION
Vue component files normally start with a capital letter (`App.vue`, `HelloWorld.vue`).

Also, `import` and `export` statements are normally separated with a space to increase readability