### PR TITLE
typescript: document type checking and baseUrl

### DIFF
--- a/src/i18n/en/docs/typeScript.md
+++ b/src/i18n/en/docs/typeScript.md
@@ -4,6 +4,8 @@ _Supported extensions: `ts`, `tsx`_
 
 [TypeScript](https://www.typescriptlang.org/) is a typed superset of JavaScript that compiles down to plain JavaScript, which also supports modern ES2015+ features. Transforming TypeScript works out of the box without any additional configuration.
 
+Parcel performs no type checking. You can use `tsc --noEmit` to have typescript check your files.
+
 ```html
 <!-- index.html -->
 <html>
@@ -67,3 +69,23 @@ ReactDOM.render(
 ```
 
 See [this full thread](https://github.com/parcel-bundler/parcel/issues/1199) for more details.
+
+## baseURL and paths
+
+Parcel does not use the `baseUrl` or `paths` directives in `tsconfig.json`. You can instead use Parcel's `~` module loading convention. Tell typescript about it like so:
+
+```json
+// tsconfig.json
+// assuming your ts sources are in ./src/
+{
+  "compilerOptions": {
+    "baseUrl": "./src",
+    "paths": {
+      "~*": ["./*"]
+    },
+  },
+  "include": ["src/**/*"]
+}
+```
+
+See [this gist](https://gist.github.com/croaky/e3394e78d419475efc79c1e418c243ed) for a full example.


### PR DESCRIPTION
These are common pain points for users.

I would recommend the parcel-plugin-typescript, but it does not work with recent versions (>1.9, maybe?) of parcel-bundler.