### PR TITLE
Clarify process.env caveat in documentation

### DIFF
--- a/src/i18n/en/docs/env.md
+++ b/src/i18n/en/docs/env.md
@@ -18,3 +18,4 @@ Notably:
 - `NODE_ENV` defaults to `development`.
 - `.env.local` is not loaded when `NODE_ENV=test` since [tests should produce the same results for everyone](https://github.com/parcel-bundler/parcel/blob/28df546a2249b6aac1e529dd629f506ba6b0a4bb/src/utils/env.js#L9)
 - Sometimes introducing a new .env file will not work immediately. Try deleting the .cache/ directory in this case.
+- Accessing the `process.env` object directly is [not supported](https://github.com/parcel-bundler/parcel/issues/2299#issuecomment-439768971), but accessing specific variables on it like `process.env.API_KEY` will provide the expected value.


### PR DESCRIPTION
Noticed this was a bit unclear and sunk some time into debugging why `console.log(process.env)` wasn't showing any values until I found the [referenced issue](https://github.com/parcel-bundler/parcel/issues/2299). Hopefully this will save someone time in the future :)