### PR TITLE
Add "autoInstall" documentation

### DIFF
--- a/src/i18n/en/docs/api.md
+++ b/src/i18n/en/docs/api.md
@@ -39,7 +39,8 @@ const options = {
   hmrPort: 0, // The port the HMR socket runs on, defaults to a random free port (0 in node.js resolves to a random free port)
   sourceMaps: true, // Enable or disable sourcemaps, defaults to enabled (minified builds currently always create sourcemaps)
   hmrHostname: '', // A hostname for hot module reload, default to ''
-  detailedReport: false // Prints a detailed report of the bundles, assets, filesizes and times, defaults to false, reports are only printed if watch is disabled
+  detailedReport: false, // Prints a detailed report of the bundles, assets, filesizes and times, defaults to false, reports are only printed if watch is disabled
+  autoInstall: true, // Enable or disable auto install of missing dependencies found during bundling
 };
 
 (async function() {


### PR DESCRIPTION
Found available option inside https://github.com/parcel-bundler/parcel/blob/master/packages/core/parcel-bundler/src/Bundler.js#L144-L149