### PR TITLE
Sync docs FR

### DIFF
--- a/src/i18n/fr/docs/api.md
+++ b/src/i18n/fr/docs/api.md
@@ -39,7 +39,8 @@ const options = {
   hmrPort: 0, // Le port sur lequel la socket HMR (Hot Module Reload) fonctionne, par défaut à un port libre aléatoire (0 dans node.js se traduit en un port libre aléatoire)
   sourceMaps: true, // Active ou désactive les sourcemaps, par défaut activé (les constructions minifiées pour l'instant créent toujours des sourcemaps)
   hmrHostname: '', // Un nom d'hôte pour le rechargement de module à chaud, par défaut à ''
-  detailedReport: false // Afficher un rapport détaillé des paquets, ressources, tailles des fichiers et durées de build, par défaut à false, les rapports ne sont affichés que si le mode watch est désactivé
+  detailedReport: false, // Afficher un rapport détaillé des paquets, ressources, tailles des fichiers et durées de build, par défaut à false, les rapports ne sont affichés que si le mode watch est désactivé
+  autoInstall: true, // Active ou désactive l'installation auto des dépendances manquantes lors de l'empaquetage
 };
 
 (async function() {

--- a/src/i18n/fr/docs/env.md
+++ b/src/i18n/fr/docs/env.md
@@ -18,3 +18,4 @@ Notamment :
 - `NODE_ENV` est par défaut à `development`.
 - `.env.local` n'est pas chargé quand `NODE_ENV=test` car [les tests doivent produire les mêmes résultats pour tout le monde](https://github.com/parcel-bundler/parcel/blob/28df546a2249b6aac1e529dd629f506ba6b0a4bb/src/utils/env.js#L9)
 - Parfois, l'introduction d'un nouveau fichier .env ne fonctionnera pas immédiatement. Essayez de supprimer dans ce cas le répertoire .cache/.
+- L’accès direct à l’objet `process.env` [n'est pas pris en charge](https://github.com/parcel-bundler/parcel/issues/2299#issuecomment-439768971), mais l’accès à des variables spécifiques comme `process.env.API_KEY` fournira la valeur attendue.

--- a/src/i18n/fr/docs/rust.md
+++ b/src/i18n/fr/docs/rust.md
@@ -25,3 +25,34 @@ pub fn add(a: i32, b: i32) -> i32 {
   return a + b
 }
 ```
+
+Vous pouvez également importer un projet rust en important `src/lib.rs` ou `src/main.rs`, Parcel appellera `cargo` pour construire le projet.
+
+```js
+import { sub } from './sub/src/lib.rs'
+console.log(sub(2, 3))
+```
+
+dans `./sub/Cargo.toml`:
+
+```toml
+[package]
+...
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wasm-bindgen = "0.2"
+```
+
+dans `./sub/src/lib.rs`:
+
+```rust
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+pub fn sub(a: i32, b: i32) -> i32 {
+    a - b
+}
+```

--- a/src/i18n/fr/docs/scss.md
+++ b/src/i18n/fr/docs/scss.md
@@ -22,6 +22,12 @@ Une fois que vous avez installé `sass`, vous pouvez importer des fichiers SCSS 
 import './custom.scss'
 ```
 
+Vous pouvez également inclure directement le fichier SCSS dans un fichier HTML.
+
+```html
+<link rel="stylesheet" href="./style.scss" />
+```
+
 Les dépendances dans les fichiers SCSS peuvent être utilisées avec les instructions `@import`.
 
 Si vous n'avez pas de module `sass` installé avant l'exécution de Parcel, Parcel l'installera automatiquement pour vous.


### PR DESCRIPTION
1. Added SCSS include example in HTML (parcel-bundler/website@0bb369a8237f02a11f98d1c7f6a9d884abf5a27f)
2. Update document of rust: How to import Cargo.toml (parcel-bundler/website@dd1fcef97150223bf65d9b6f35664e30acb5008a)
3. Clarify process.env caveat in documentation (parcel-bundler/website@5caa51e6b20fdc033faa01d94aaa3e6ea4a6872e)
4. Add "autoInstall" documentation (parcel-bundler/website@18d74a5249a24ef90a7a6f69d2952520a7a36645)