### PR TITLE
Fix typo in language picker: Polskie -> Polski

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Change the displayed language using a query string, access various version using
 * Italiano: http://localhost:5000/?locale=it
 * 日本語: http://localhost:5000/?locale=ja
 * 한국어: http://localhost:5000/?locale=ko
-* Polskie: http://localhost:5000/?locale=pl
+* Polski: http://localhost:5000/?locale=pl
 * Português: http://localhost:5000/?locale=pt
 * Русский: http://localhost:5000/?locale=ru
 * Українська: http://localhost:5000/?locale=uk

--- a/src/i18n/en/index.html
+++ b/src/i18n/en/index.html
@@ -72,7 +72,7 @@
             <option class="it" value="https://it.parceljs.org">Italiano</option>
             <option class="ja" value="https://ja.parceljs.org">日本語</option>
             <option class="ko" value="https://ko.parceljs.org">한국어</option>
-            <option class="pl" value="https://pl.parceljs.org">Polskie</option>
+            <option class="pl" value="https://pl.parceljs.org">Polski</option>
             <option class="pt" value="https://pt.parceljs.org">Português</option>
             <option class="ru" value="https://ru.parceljs.org">Русский</option>
             <option class="uk" value="https://uk.parceljs.org">Українська</option>

--- a/src/i18n/en/layout/page.html
+++ b/src/i18n/en/layout/page.html
@@ -46,7 +46,7 @@
             <option class="it" value="https://it.parceljs.org">Italiano</option>
             <option class="ja" value="https://ja.parceljs.org">日本語</option>
             <option class="ko" value="https://ko.parceljs.org">한국어</option>
-            <option class="pl" value="https://pl.parceljs.org">Polskie</option>
+            <option class="pl" value="https://pl.parceljs.org">Polski</option>
             <option class="pt" value="https://pt.parceljs.org">Português</option>
             <option class="ru" value="https://ru.parceljs.org">Русский</option>
             <option class="uk" value="https://uk.parceljs.org">Українська</option>

--- a/src/i18n/es/index.html
+++ b/src/i18n/es/index.html
@@ -66,7 +66,7 @@
             <option class="it" value="https://it.parceljs.org">Italiano</option>
             <option class="ja" value="https://ja.parceljs.org">日本語</option>
             <option class="ko" value="https://ko.parceljs.org">한국어</option>
-            <option class="pl" value="https://pl.parceljs.org">Polskie</option>
+            <option class="pl" value="https://pl.parceljs.org">Polski</option>
             <option class="pt" value="https://pt.parceljs.org">Português</option>
             <option class="ru" value="https://ru.parceljs.org">Русский</option>
             <option class="uk" value="https://uk.parceljs.org">Українська</option>

--- a/src/i18n/es/layout/page.html
+++ b/src/i18n/es/layout/page.html
@@ -46,7 +46,7 @@
             <option class="it" value="https://it.parceljs.org">Italiano</option>
             <option class="ja" value="https://ja.parceljs.org">日本語</option>
             <option class="ko" value="https://ko.parceljs.org">한국어</option>
-            <option class="pl" value="https://pl.parceljs.org">Polskie</option>
+            <option class="pl" value="https://pl.parceljs.org">Polski</option>
             <option class="pt" value="https://pt.parceljs.org">Português</option>
             <option class="ru" value="https://ru.parceljs.org">Русский</option>
             <option class="uk" value="https://uk.parceljs.org">Українська</option>

--- a/src/i18n/fr/index.html
+++ b/src/i18n/fr/index.html
@@ -73,7 +73,7 @@
             <option class="it" value="https://it.parceljs.org">Italiano</option>
             <option class="ja" value="https://ja.parceljs.org">日本語</option>
             <option class="ko" value="https://ko.parceljs.org">한국어</option>
-            <option class="pl" value="https://pl.parceljs.org">Polskie</option>
+            <option class="pl" value="https://pl.parceljs.org">Polski</option>
             <option class="pt" value="https://pt.parceljs.org">Português</option>
             <option class="ru" value="https://ru.parceljs.org">Русский</option>
             <option class="uk" value="https://uk.parceljs.org">Українська</option>

--- a/src/i18n/fr/layout/page.html
+++ b/src/i18n/fr/layout/page.html
@@ -46,7 +46,7 @@
             <option class="it" value="https://it.parceljs.org">Italiano</option>
             <option class="ja" value="https://ja.parceljs.org">日本語</option>
             <option class="ko" value="https://ko.parceljs.org">한국어</option>
-            <option class="pl" value="https://pl.parceljs.org">Polskie</option>
+            <option class="pl" value="https://pl.parceljs.org">Polski</option>
             <option class="pt" value="https://pt.parceljs.org">Português</option>
             <option class="ru" value="https://ru.parceljs.org">Русский</option>
             <option class="uk" value="https://uk.parceljs.org">Українська</option>

--- a/src/i18n/it/index.html
+++ b/src/i18n/it/index.html
@@ -66,7 +66,7 @@
             <option class="it" value="https://it.parceljs.org" selected>Italiano</option>
             <option class="ja" value="https://ja.parceljs.org">日本語</option>
             <option class="ko" value="https://ko.parceljs.org">한국어</option>
-            <option class="pl" value="https://pl.parceljs.org">Polskie</option>
+            <option class="pl" value="https://pl.parceljs.org">Polski</option>
             <option class="pt" value="https://pt.parceljs.org">Português</option>
             <option class="ru" value="https://ru.parceljs.org">Русский</option>
             <option class="uk" value="https://uk.parceljs.org">Українська</option>

--- a/src/i18n/it/layout/page.html
+++ b/src/i18n/it/layout/page.html
@@ -46,7 +46,7 @@
             <option class="it" value="https://it.parceljs.org" selected>Italiano</option>
             <option class="ja" value="https://ja.parceljs.org">日本語</option>
             <option class="ko" value="https://ko.parceljs.org">한국어</option>
-            <option class="pl" value="https://pl.parceljs.org">Polskie</option>
+            <option class="pl" value="https://pl.parceljs.org">Polski</option>
             <option class="pt" value="https://pt.parceljs.org">Português</option>
             <option class="ru" value="https://ru.parceljs.org">Русский</option>
             <option class="uk" value="https://uk.parceljs.org">Українська</option>

--- a/src/i18n/ja/index.html
+++ b/src/i18n/ja/index.html
@@ -73,7 +73,7 @@
             <option class="it" value="https://it.parceljs.org">Italiano</option>
             <option class="ja" value="https://ja.parceljs.org" selected>日本語</option>
             <option class="ko" value="https://ko.parceljs.org">한국어</option>
-            <option class="pl" value="https://pl.parceljs.org">Polskie</option>
+            <option class="pl" value="https://pl.parceljs.org">Polski</option>
             <option class="pt" value="https://pt.parceljs.org">Português</option>
             <option class="ru" value="https://ru.parceljs.org">Русский</option>
             <option class="uk" value="https://uk.parceljs.org">Українська</option>

--- a/src/i18n/ja/layout/page.html
+++ b/src/i18n/ja/layout/page.html
@@ -46,7 +46,7 @@
             <option class="it" value="https://it.parceljs.org">Italiano</option>
             <option class="ja" value="https://ja.parceljs.org" selected>日本語</option>
             <option class="ko" value="https://ko.parceljs.org">한국어</option>
-            <option class="pl" value="https://pl.parceljs.org">Polskie</option>
+            <option class="pl" value="https://pl.parceljs.org">Polski</option>
             <option class="pt" value="https://pt.parceljs.org">Português</option>
             <option class="ru" value="https://ru.parceljs.org">Русский</option>
             <option class="uk" value="https://uk.parceljs.org">Українська</option>

--- a/src/i18n/ko/index.html
+++ b/src/i18n/ko/index.html
@@ -67,7 +67,7 @@
             <option class="it" value="https://it.parceljs.org">Italiano</option>
             <option class="ja" value="https://ja.parceljs.org">日本語</option>
             <option class="ko" value="https://ko.parceljs.org" selected>한국어</option>
-            <option class="pl" value="https://pl.parceljs.org">Polskie</option>
+            <option class="pl" value="https://pl.parceljs.org">Polski</option>
             <option class="pt" value="https://pt.parceljs.org">Português</option>
             <option class="ru" value="https://ru.parceljs.org">Русский</option>
             <option class="uk" value="https://uk.parceljs.org">Українська</option>

--- a/src/i18n/ko/layout/page.html
+++ b/src/i18n/ko/layout/page.html
@@ -47,7 +47,7 @@
             <option class="it" value="https://it.parceljs.org">Italiano</option>
             <option class="ja" value="https://ja.parceljs.org">日本語</option>
             <option class="ko" value="https://ko.parceljs.org" selected>한국어</option>
-            <option class="pl" value="https://pl.parceljs.org">Polskie</option>
+            <option class="pl" value="https://pl.parceljs.org">Polski</option>
             <option class="pt" value="https://pt.parceljs.org">Português</option>
             <option class="ru" value="https://ru.parceljs.org">Русский</option>
             <option class="uk" value="https://uk.parceljs.org">Українська</option>

--- a/src/i18n/pl/layout/page.html
+++ b/src/i18n/pl/layout/page.html
@@ -46,7 +46,7 @@
             <option class="it" value="https://it.parceljs.org">Italiano</option>
             <option class="ja" value="https://ja.parceljs.org">日本語</option>
             <option class="ko" value="https://ko.parceljs.org">한국어</option>
-            <option class="pl" value="https://pl.parceljs.org" selected>Polskie</option>
+            <option class="pl" value="https://pl.parceljs.org" selected>Polski</option>
             <option class="pt" value="https://pt.parceljs.org">Português</option>
             <option class="ru" value="https://ru.parceljs.org">Русский</option>
             <option class="uk" value="https://uk.parceljs.org">Українська</option>

--- a/src/i18n/pt/index.html
+++ b/src/i18n/pt/index.html
@@ -66,7 +66,7 @@
             <option class="it" value="https://it.parceljs.org">Italiano</option>
             <option class="ja" value="https://ja.parceljs.org">日本語</option>
             <option class="ko" value="https://ko.parceljs.org">한국어</option>
-            <option class="pl" value="https://pl.parceljs.org">Polskie</option>
+            <option class="pl" value="https://pl.parceljs.org">Polski</option>
             <option class="pt" value="https://pt.parceljs.org" selected>Português</option>
             <option class="ru" value="https://ru.parceljs.org">Русский</option>
             <option class="uk" value="https://uk.parceljs.org">Українська</option>

--- a/src/i18n/pt/layout/page.html
+++ b/src/i18n/pt/layout/page.html
@@ -46,7 +46,7 @@
             <option class="it" value="https://it.parceljs.org">Italiano</option>
             <option class="ja" value="https://ja.parceljs.org">日本語</option>
             <option class="ko" value="https://ko.parceljs.org">한국어</option>
-            <option class="pl" value="https://pl.parceljs.org">Polskie</option>
+            <option class="pl" value="https://pl.parceljs.org">Polski</option>
             <option class="pt" value="https://pt.parceljs.org" selected>Português</option>
             <option class="ru" value="https://ru.parceljs.org">Русский</option>
             <option class="uk" value="https://uk.parceljs.org">Українська</option>

--- a/src/i18n/ru/index.html
+++ b/src/i18n/ru/index.html
@@ -66,7 +66,7 @@
             <option class="it" value="https://it.parceljs.org">Italiano</option>
             <option class="ja" value="https://ja.parceljs.org">日本語</option>
             <option class="ko" value="https://ko.parceljs.org">한국어</option>
-            <option class="pl" value="https://pl.parceljs.org">Polskie</option>
+            <option class="pl" value="https://pl.parceljs.org">Polski</option>
             <option class="pt" value="https://pt.parceljs.org">Português</option>
             <option class="ru" value="https://ru.parceljs.org" selected>Русский</option>
             <option class="uk" value="https://uk.parceljs.org">Українська</option>

--- a/src/i18n/ru/layout/page.html
+++ b/src/i18n/ru/layout/page.html
@@ -46,7 +46,7 @@
             <option class="it" value="https://it.parceljs.org">Italiano</option>
             <option class="ja" value="https://ja.parceljs.org">日本語</option>
             <option class="ko" value="https://ko.parceljs.org">한국어</option>
-            <option class="pl" value="https://pl.parceljs.org">Polskie</option>
+            <option class="pl" value="https://pl.parceljs.org">Polski</option>
             <option class="pt" value="https://pt.parceljs.org">Português</option>
             <option class="ru" value="https://ru.parceljs.org" selected>Русский</option>
             <option class="uk" value="https://uk.parceljs.org">Українська</option>

--- a/src/i18n/uk/index.html
+++ b/src/i18n/uk/index.html
@@ -66,7 +66,7 @@
             <option class="it" value="https://it.parceljs.org">Italiano</option>
             <option class="ja" value="https://ja.parceljs.org">日本語</option>
             <option class="ko" value="https://ko.parceljs.org">한국어</option>
-            <option class="pl" value="https://pl.parceljs.org">Polskie</option>
+            <option class="pl" value="https://pl.parceljs.org">Polski</option>
             <option class="pt" value="https://pt.parceljs.org">Português</option>
             <option class="ru" value="https://ru.parceljs.org">Русский</option>
             <option class="uk" value="https://uk.parceljs.org" selected>Українська</option>

--- a/src/i18n/uk/layout/page.html
+++ b/src/i18n/uk/layout/page.html
@@ -46,7 +46,7 @@
             <option class="it" value="https://it.parceljs.org">Italiano</option>
             <option class="ja" value="https://ja.parceljs.org">日本語</option>
             <option class="ko" value="https://ko.parceljs.org">한국어</option>
-            <option class="pl" value="https://pl.parceljs.org">Polskie</option>
+            <option class="pl" value="https://pl.parceljs.org">Polski</option>
             <option class="pt" value="https://pt.parceljs.org">Português</option>
             <option class="ru" value="https://ru.parceljs.org">Русский</option>
             <option class="uk" value="https://uk.parceljs.org" selected>Українська</option>

--- a/src/i18n/zh-tw/index.html
+++ b/src/i18n/zh-tw/index.html
@@ -53,7 +53,7 @@
           <option class="it" value="https://it.parceljs.org">Italiano</option>
           <option class="ja" value="https://ja.parceljs.org">日本語</option>
           <option class="ko" value="https://ko.parceljs.org">한국어</option>
-          <option class="pl" value="https://pl.parceljs.org">Polskie</option>
+          <option class="pl" value="https://pl.parceljs.org">Polski</option>
           <option class="pt" value="https://pt.parceljs.org">Português</option>
           <option class="ru" value="https://ru.parceljs.org">Русский</option>
           <option class="zh" value="https://zh.parceljs.org">简体中文</option>

--- a/src/i18n/zh-tw/layout/page.html
+++ b/src/i18n/zh-tw/layout/page.html
@@ -35,7 +35,7 @@
           <option class="it" value="https://it.parceljs.org">Italiano</option>
           <option class="ja" value="https://ja.parceljs.org">日本語</option>
           <option class="ko" value="https://ko.parceljs.org">한국어</option>
-          <option class="pl" value="https://pl.parceljs.org">Polskie</option>
+          <option class="pl" value="https://pl.parceljs.org">Polski</option>
           <option class="pt" value="https://pt.parceljs.org">Português</option>
           <option class="ru" value="https://ru.parceljs.org">Русский</option>
           <option class="zh" value="https://zh.parceljs.org">简体中文</option>

--- a/src/i18n/zh/index.html
+++ b/src/i18n/zh/index.html
@@ -81,7 +81,7 @@
             <option class="it" value="https://it.parceljs.org">Italiano</option>
             <option class="ja" value="https://ja.parceljs.org">日本語</option>
             <option class="ko" value="https://ko.parceljs.org">한국어</option>
-            <option class="pl" value="https://pl.parceljs.org">Polskie</option>
+            <option class="pl" value="https://pl.parceljs.org">Polski</option>
             <option class="pt" value="https://pt.parceljs.org">Português</option>
             <option class="ru" value="https://ru.parceljs.org">Русский</option>
             <option class="uk" value="https://uk.parceljs.org">Українська</option>

--- a/src/i18n/zh/layout/page.html
+++ b/src/i18n/zh/layout/page.html
@@ -46,7 +46,7 @@
             <option class="it" value="https://it.parceljs.org">Italiano</option>
             <option class="ja" value="https://ja.parceljs.org">日本語</option>
             <option class="ko" value="https://ko.parceljs.org">한국어</option>
-            <option class="pl" value="https://pl.parceljs.org">Polskie</option>
+            <option class="pl" value="https://pl.parceljs.org">Polski</option>
             <option class="pt" value="https://pt.parceljs.org">Português</option>
             <option class="ru" value="https://ru.parceljs.org">Русский</option>
             <option class="uk" value="https://uk.parceljs.org">Українська</option>


### PR DESCRIPTION
Hello!
First of all thank you for parcel, love it!

I noticed a typo in language picker on the parcel website for Polish language. It should be `Polski` instead of `Polskie`. Im a native speaker so I instantly spotted this tiny mistake.

This PR fixes this typo.