### PR TITLE
Update recipes.md with setup for Svelte

### DIFF
--- a/src/i18n/en/docs/recipes.md
+++ b/src/i18n/en/docs/recipes.md
@@ -223,3 +223,52 @@ Then, in your `index.html` file, add a reference to your JavaScript entry point.
 ```
 
 Done!
+
+## Svelte
+
+First we need to install the dependencies for Svelte.
+
+[Blog Post](https://dev.to/alexparra/basic-svelte-app-with-parcel-30i5)
+
+```bash
+npm install --save-dev svelte
+npm install --save-dev parcel-plugin-svelte
+npm install --save-dev parcel-bundler
+```
+
+<sub>Or if you have the optional Yarn package manager installed</sub>
+
+```bash
+yarn add --dev svelte
+yarn add --dev parcel-plugin-svelte
+yarn add --dev parcel-bundler
+```
+
+### Compiling from index.html
+
+Add Start script to `package.json`
+
+```javascript
+// package.json
+"scripts": {
+  "start": "parcel src/index.html"
+}
+```
+
+Then, in your `index.html` file, add a reference to your JavaScript entry point.
+
+```html
+<!-- .src/index.html -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>My Svelte App</title>
+</head>
+<body>
+    <!-- Here 👇 -->
+    <script src="./src/main.js"></script>
+</body>
+</html>
+```
+
+Done!


### PR DESCRIPTION
Added setup steps for Svelte in-line with the existing content for React, Preact, Vue, etc.
Added to bottom but suggest it's pulled up to show next to the other frameworks.