### PR TITLE
Replace placeholder according to Korean meaning

### DIFF
--- a/src/i18n/ko/layout/page.html
+++ b/src/i18n/ko/layout/page.html
@@ -36,7 +36,7 @@
       </a>
       <div class="links">
         <div class="search-input-wrapper">
-          <input type="text" id="search-input" class="search-input" placeholder="수색..." />
+          <input type="text" id="search-input" class="search-input" placeholder="검색..." />
         </div>
         <form class="languages">
           <select


### PR DESCRIPTION
I'm korean developer using and interested in parcel-bundler.
I found that search input placeholder is not according to Korean meaning.
`검색` is more in korean meaning than `수색`.

Review my PR for more korean developers using parcel-bundler.
Thanks.