### PR TITLE
Updated `new Vue()` line with `createElement()`

### DIFF
--- a/src/i18n/en/docs/vue.md
+++ b/src/i18n/en/docs/vue.md
@@ -56,5 +56,5 @@ export default Vue.extend({
 import Vue from 'vue';
 import App from './App.vue';
 
-new Vue(App).$mount('#app')
+new Vue({ render: createElement => createElement(App) }).$mount('#app');
 ```


### PR DESCRIPTION
Upon following this guide I realized an error with the previous `new Vue(App).$mount('#app');` line. After some searching I found the `createElement` alternative which works without error.