### PR TITLE
Fix typo npm organizations

### DIFF
--- a/src/i18n/en/docs/module_resolution.md
+++ b/src/i18n/en/docs/module_resolution.md
@@ -61,7 +61,7 @@ This example aliases `react` to `preact` and some local custom module that is no
 Avoid using any special characters in your aliases as some may be used by Parcel and others by 3rd party tools or extensions. For example:
 
 - `~` used by Parcel to resolve [tilde paths](#~-tilde-paths).
-- `@` used by npm to resolve npm organisations.
+- `@` used by npm to resolve npm organizations.
 
 We advise being explicit when defining your aliases, so please **specify file extensions**, otherwise Parcel will need to guess. See [JavaScript Named Exports](#javascript-named-exports) for an example of this.
 


### PR DESCRIPTION
Fix typo for npm organizations. When I translate page module-resolution in Korean, I found the word organisation. So, I found [npm page](https://www.npmjs.com/), They named **npm organization**. 

It could be correct organisations word, So If correct, I will close this pull request.
Thank you. :)