### PR TITLE
Update api.md

### DIFF
--- a/src/i18n/en/docs/api.md
+++ b/src/i18n/en/docs/api.md
@@ -34,7 +34,7 @@ const options = {
     cert: './ssl/c.crt', // Path to custom certificate
     key: './ssl/k.key' // Path to custom key
   },
-  logLevel: 3, // 5 = save everything to a file, 4 = like 3, but with timestamps and additionally log http requests to dev server, 3 = log info, warnings & errors, 2 = log warnings & errors, 1 = log errors
+  logLevel: 3, // 5 = save everything to a file, 4 = like 3, but with timestamps and additionally log http requests to dev server, 3 = log info, warnings & errors, 2 = log warnings & errors, 1 = log errors, 0 = log nothing
   hmr: true, // Enable or disable HMR while watching
   hmrPort: 0, // The port the HMR socket runs on, defaults to a random free port (0 in node.js resolves to a random free port)
   sourceMaps: true, // Enable or disable sourcemaps, defaults to enabled (minified builds currently always create sourcemaps)


### PR DESCRIPTION
It looks like it is possible to configure Parcel to log nothing by passing 0 as the `logLevel` option value.

TypeScript definitions are wrong though. They onle declare 3, 2 and 1 as possible values. They need to be fixed.