### PR TITLE
Update docs to mention required TypeScript types

### DIFF
--- a/src/i18n/en/docs/typeScript.md
+++ b/src/i18n/en/docs/typeScript.md
@@ -89,3 +89,7 @@ Parcel does not use the `baseUrl` or `paths` directives in `tsconfig.json`. You 
 ```
 
 See [this gist](https://gist.github.com/croaky/e3394e78d419475efc79c1e418c243ed) for a full example.
+
+## Module API types
+
+To interact with Parcel's Module API (e.g. when setting up [Hot Module Replacement](https://parceljs.org/hmr.html)), make sure to install the `@types/parcel-env` package.


### PR DESCRIPTION
When setting up HMR, the TypeScript compiler would complain as it isn't aware of Parcel's module API. To fix this, types has been added ([see this issue](https://github.com/parcel-bundler/parcel/issues/1063)).

This PR updates the docs so that people are aware of this and don't end up getting the same error.