### PR TITLE
Improve use of inclusive language

### DIFF
--- a/src/i18n/en/index.html
+++ b/src/i18n/en/index.html
@@ -173,7 +173,7 @@ main();</code></pre>
 
         <p>
           Run <code>parcel index.html</code> to start a dev server. Importing JavaScript, CSS, images, and more just
-          works! 👌
+          works! 👍
         </p>
       </section>
 


### PR DESCRIPTION
I've replaced the 👌 [ok hand] emoji in the *[Hello World](https://parceljs.org/)* section with a 👍[thumbs up] emoji.

The reasoning behind this change is to remove harmful
language from the documentation:

> The hand gesture has been used by White Supremacists
> as a dogwhistle to identify other White Supremacists 
> at rallies, in forums, and even at court hearings. 
> In 2019, the hand gesture was added to the 
> Anti-Defamation League's list of official symbols 
> of hate.
>
> [👌 [ok hand] at Self-Defined](https://www.selfdefined.app/#ok-hand)