### PR TITLE
fix misspelling

### DIFF
--- a/src/i18n/en/docs/pug.md
+++ b/src/i18n/en/docs/pug.md
@@ -39,7 +39,7 @@ doctype html
 html(lang="")
   head
     // ...
-    link(rel="stylesheet", href="index.css")
+    link(rel="stylesheet", href="style.css")
   body
     h1 Hello
 


### PR DESCRIPTION
According to the file structure example it should be `style.css`, not `index.css`.