### PR TITLE
Correct heading in OpenGL.md

### DIFF
--- a/src/i18n/en/docs/openGL.md
+++ b/src/i18n/en/docs/openGL.md
@@ -4,7 +4,7 @@ _Supported extensions: `glsl`, `vert`, `frag`_
 
 # Examples of GLSL code
 
-## Vertex shader
+## Fragment shader
 
 `shader.frag`:
 


### PR DESCRIPTION
The sample shader is a fragment shader, not a vertex shader.