### PR TITLE
Update scss.md

### DIFF
--- a/src/i18n/en/docs/scss.md
+++ b/src/i18n/en/docs/scss.md
@@ -2,7 +2,9 @@
 
 _Supported extensions: `sass`, `scss`_
 
-SCSS compilation needs `sass` (JS version of `dart-sass`) module. 
+## Requirements
+
+SCSS compilation needs `sass` (JS version of `dart-sass`) module. This will be installed automatically the first time you run parcel. It's also possible to install it manually before running parcel.
 
 To install it with npm:
 
@@ -16,7 +18,26 @@ To install it with yarn:
 yarn add -D sass
 ```
 
-Once you have `sass` installed you can import SCSS files from JavaScript files.
+It's also strongly recommended to create a `.sassrc` file and add `node_modules` as include path to avoid an [issue](https://github.com/parcel-bundler/parcel/issues/39#issuecomment-443061650)
+
+```
+{
+  "includePaths": ["node_modules"]
+}
+```
+
+This file controls the sass compilation with Parcel. Another thing that can be configured is the output style of the generated CSS by specifying it like so:
+
+```
+{
+  "includePaths": ["node_modules"],
+  outputStyle: "nested",
+}
+```
+
+## Usage
+
+To use `sass` you can import SCSS files from JavaScript files.
 
 ```javascript
 import './custom.scss'
@@ -28,17 +49,6 @@ You can also directly include the SCSS file in a HTML file.
 ```
 
 Dependencies in the SCSS files can be used with the `@import` statements.
-
-If you don't have `sass` module installed before running Parcel, Parcel will install it automatically for you.
-
-Additionally, you can configure sass compilation with Parcel by creating a configuration file such as: .sassrc
-
-For instance, you can control the output style of the generated CSS by specifying it like so:
-
-{
-  outputStyle: "nested",
-}
-
 
 **Notes:** You can also use `node-sass` module for SCSS compilation. Using `node-sass` module will give you faster compilation. However, [an issue](https://github.com/parcel-bundler/parcel/issues/1836) has been reported using `node-sass` module with Parcel.
 


### PR DESCRIPTION
Why let people go through the motion of installing stuff then stating at the bottom "it will be installed automatically anyway" ..

In the experience of 27 people the `include_path` is necessary for sass to even work properly, so let's put that in the documentation as well.