### PR TITLE
Update scss.md

### DIFF
--- a/src/i18n/en/docs/scss.md
+++ b/src/i18n/en/docs/scss.md
@@ -31,7 +31,7 @@ This file controls the sass compilation with Parcel. Another thing that can be c
 ```
 {
   "includePaths": ["node_modules"],
-  outputStyle: "nested",
+  outputStyle: "compressed",
 }
 ```
 


### PR DESCRIPTION
The `nested` style throws an error as not supported with `sass` module.