### PR TITLE
Fix module resolution order

### DIFF
--- a/src/features/module-resolution.md
+++ b/src/features/module-resolution.md
@@ -73,8 +73,8 @@ Without scope hoisting however, `main` is preferred to `module` for better perfo
 
 - `package.json#source`
 - `package.json#browser`
-- `package.json#module`
 - `package.json#main`
+- `package.json#module`
 - `index.{js, json}`
 
 ## Common issues


### PR DESCRIPTION
The following sentence suggests that the resolution order is different when scope hoisting is is disabled:

> Without scope hoisting however, main is preferred to module for better performance:

However, the following list is identical to the previous one (if scope hoisting is enabled). I did not check the actual implementation, so changing the order in the list to match what the sentence is saying might not be the correct fix.