### PR TITLE
typeScript.md: Fix compilerOptions.paths

### DIFF
--- a/src/i18n/en/docs/typeScript.md
+++ b/src/i18n/en/docs/typeScript.md
@@ -81,7 +81,7 @@ Parcel does not use the `baseUrl` or `paths` directives in `tsconfig.json`. You 
   "compilerOptions": {
     "baseUrl": "./src",
     "paths": {
-      "~*": ["./*"]
+      "~/*": ["./*"]
     },
   },
   "include": ["src/**/*"]


### PR DESCRIPTION
The official document's tsconfig.json is different from [the gist](https://gist.github.com/croaky/e3394e78d419475efc79c1e418c243ed#file-tsconfig-json) .

As suggested in the gist, it works better with vscode after the fix.