### PR TITLE
Correct naming pattern for file hash

### DIFF
--- a/src/i18n/en/docs/production.md
+++ b/src/i18n/en/docs/production.md
@@ -36,7 +36,7 @@ Parcel follows the following table, when it comes to naming bundles (Entrypoints
 |                          HTML | anchor link        |       ❌       |
 | Raw (Images, text files, ...) | Import/Require/... |       ✅       |
 
-The file hash follows the following naming pattern: `<directory name>-<hash>.<extension>`
+The file hash follows the following naming pattern: `<directory name>.<hash>.<extension>`
 
 ## Cross platform gotchas
 


### PR DESCRIPTION
Looks like the naming pattern for file hash is outdated.
For 1.12.4, this the used pattern: `<directory name>.<hash>.<extension>`

Here's a screenshot for the behavior I'm getting for 1.12.4.
![Screen Shot 2020-08-18 at 12 37 16](https://user-images.githubusercontent.com/106093/90534157-c743d980-e14f-11ea-81ce-79f74d8d2475.png)
