### PR TITLE
Update cli.md with a note about glob patterns

### DIFF
--- a/src/features/cli.md
+++ b/src/features/cli.md
@@ -26,6 +26,16 @@ parcel a.html b.html
 parcel ./**/*.html
 ```
 
+NOTE: If a glob pattern ends in an asterisk `*`, be sure to wrap the glob in single quotes, otherwise you may experience issues caused by your shell.
+
+```bash
+# OK
+parcel './img/**/*'
+
+# Not OK
+parcel ./img/**/*
+```
+
 {% warning %}
 
 If you have specified multiple HTML entry points and none of them is has the output path `/index.html`, the dev server will respond to `localhost:1234/` with a 404, since Parcel doesn't know which HTML bundle is the index.

--- a/src/features/cli.md
+++ b/src/features/cli.md
@@ -15,6 +15,22 @@ The "entries" in all commands can be:
 - one or more globs
 - one or more directorises (see [Specifying Entrypoints](/getting-started/configuration/#specifying-entrypoints))
 
+{% warning %}
+
+If a glob pattern contains a wildcard `*`, be sure to wrap the pattern in single quotes. This ensures that Parcel reads the pattern correctly without it being manipulated by your shell.
+
+```bash
+# OK
+parcel './**/*.html'
+parcel './img/**/*'
+
+# Not OK
+parcel ./**/*.html
+parcel ./img/**/*
+```
+
+{% endwarning %}
+
 ### `parcel [serve] <entries>`
 
 Starts up a development server, which will automatically rebuild your app as you change files and supports [hot module replacement](/features/hmr/).
@@ -23,17 +39,7 @@ You may also pass a glob or list of globs for multiple entry points:
 ```bash
 parcel index.html
 parcel a.html b.html
-parcel ./**/*.html
-```
-
-NOTE: If a glob pattern ends in an asterisk `*`, be sure to wrap the glob in single quotes, otherwise you may experience issues caused by your shell.
-
-```bash
-# OK
-parcel './img/**/*'
-
-# Not OK
-parcel ./img/**/*
+parcel './**/*.html'
 ```
 
 {% warning %}


### PR DESCRIPTION
Bit of a gotcha with regards to glob patterns that I think is worth calling out.

If you have a file tree and you run `parcel build ./**/*` without any extension it won't find the files correctly. `parcel build './**/*'` works as expected.