### PR TITLE
Fix import in API proxy section

### DIFF
--- a/src/features/api-proxy.md
+++ b/src/features/api-proxy.md
@@ -38,10 +38,23 @@ This would cause `http://localhost:1234/api/endpoint` to be proxied to `http://l
 For more complex configurations, a `.proxyrc.js` file allows you to attach any (connect-compatible) middleware, this example has the same behaviour as the `.proxyrc` version above.
 
 {% sample %}
+{% samplefile "package.json" %}
+
+```json
+{
+  "devDependencies": {
+    "http-proxy-middleware": "^1.0.0",
+    "parcel": "next"
+  }
+}
+```
+
+{% endsamplefile %}
+
 {% samplefile ".proxyrc.js" %}
 
 ```js
-const createProxyMiddleware = require("http-proxy-middleware");
+const { createProxyMiddleware } = require("http-proxy-middleware");
 
 module.exports = function (app) {
   app.use(

--- a/src/features/api-proxy.md
+++ b/src/features/api-proxy.md
@@ -41,7 +41,7 @@ For more complex configurations, a `.proxyrc.js` file allows you to attach any (
 {% samplefile ".proxyrc.js" %}
 
 ```js
-const { createProxyMiddleware } = require("http-proxy-middleware");
+const createProxyMiddleware = require("http-proxy-middleware");
 
 module.exports = function (app) {
   app.use(


### PR DESCRIPTION
Since `reporter-dev-server` depends on `http-proxy-middleware ^0.19.1`, the import is incorrect. From `^1.0.0`  onwards, it would be correct, as the API was changed.