### PR TITLE
Minor typo fix and Elm init flag removal

### DIFF
--- a/src/languages/elm.md
+++ b/src/languages/elm.md
@@ -6,9 +6,9 @@ eleventyNavigation:
   order: 9
 ---
 
-You can import [Elm](https://elm-lang.org/) files like any another Javascript files.
+You can import [Elm](https://elm-lang.org/) files like any another JavaScript files.
 
-The npm package `elm` needs to be manually installed beforehand. You'll also need a `elm.json` configuration file (run `yarn elm init -y` to get started and modify it if neccessary).
+The npm package `elm` needs to be manually installed beforehand. You'll also need a `elm.json` configuration file (run `yarn elm init` to get started and modify it if necessary).
 
 {% sample null, "column" %}
 {% samplefile "index.html" %}


### PR DESCRIPTION
As running `yarn elm init -y` failed with Elm 0.19.1:

```sh
yarn elm init -y
yarn run v1.21.1
$ /home/user/project/node_modules/.bin/elm init -y
I do not recognize this flag:

    -y
```

Here's a simple PR.

Thanks for your awesome work on Parcel and the docs BTW. :+1: 