### PR TITLE
Fix SVG htmlnano documentation

### DIFF
--- a/src/languages/html.md
+++ b/src/languages/html.md
@@ -273,7 +273,9 @@ The result should be:
 
 If minification is enabled (e.g. `parcel build` without `--no-minify`) all bundles are automatically processed with [htmlnano](https://github.com/posthtml/htmlnano).
 
-It can be configured according to its documentation with a .htmlnanorc (JSON) or .htmlnanorc.js file, for example to retain HTML comments
+It can be configured according to its documentation with a .htmlnanorc (JSON) or .htmlnanorc.js file. Make sure to delete the .parcel-cache directory after changing htmlnano settings.
+
+For example to retain HTML comments
 
 {% sample %}
 {% samplefile ".htmlnanorc" %}
@@ -294,7 +296,7 @@ or to not minify SVG elements.
 
 ```json
 {
-  "minifySVG": false
+  "minifySvg": false
 }
 ```
 


### PR DESCRIPTION
Hi,

The htmlnano setting key must be `minifySvg` and not `minifySVG` . This PR probably fixes #441 

Ref: 
https://github.com/posthtml/htmlnano#minifysvg
https://github.com/parcel-bundler/parcel/issues/1523#issuecomment-431613312