### PR TITLE
plugin-configuration.md - exampel with "..." in extending config

### DIFF
--- a/src/configuration/plugin-configuration.md
+++ b/src/configuration/plugin-configuration.md
@@ -79,7 +79,7 @@ A common usecase is extending the default config, for this reason the `extends` 
 {% endsamplefile %}
 {% endsample %}
 
-If default config need to be extended (for example additional reporters needs to be added, but default ones need to stay), add `"..."` to extend list provided by config specified in `extends` field.
+To add additional plugins while not overwriting the but default ones, add `"..."` to use the plugins provided by config specified in the `extends` field. For example to add an additional reporter:
 
 {% sample %}
 {% samplefile ".parcelrc" %}

--- a/src/configuration/plugin-configuration.md
+++ b/src/configuration/plugin-configuration.md
@@ -87,7 +87,7 @@ If default config need to be extended (for example additional reporters needs to
 ```json/1
 {
   "extends": "@parcel/config-default",
-  "reporters": ["...", "@parcel/reporter-dev-server"]
+  "reporters": ["...", "parcel-reporter-custom"]
 }
 ```
 

--- a/src/configuration/plugin-configuration.md
+++ b/src/configuration/plugin-configuration.md
@@ -79,6 +79,22 @@ A common usecase is extending the default config, for this reason the `extends` 
 {% endsamplefile %}
 {% endsample %}
 
+If default config need to be extended (for example additional reporters needs to be added, but default ones need to stay), add `"..."` to extend list provided by config specified in `extends` field.
+
+{% sample %}
+{% samplefile ".parcelrc" %}
+
+```json/1
+{
+  "extends": "@parcel/config-default",
+  "reporters": ["...", "@parcel/reporter-dev-server"]
+}
+```
+
+{% endsamplefile %}
+{% endsample %}
+
+
 ### Pipelines
 
 The observant reader might have noticed that the last config example didn't include `@parcel/transformer-js`, which is required for `@parcel/runtime-js` and `@parcel/runtime-packager`.


### PR DESCRIPTION
Example of extending configuration with `"..."` in extending config section based on reporters plugins.

There is usage example of `"..."` in next section, but it could be beneficial (from user perspective) to add
similar info in the `Extending configs` section, as it looks like main place to answer the question 
"how to extend some config by adding custom configuration".