### PR TITLE
Update glob pattern to find html files

### DIFF
--- a/src/i18n/en/docs/getting_started.md
+++ b/src/i18n/en/docs/getting_started.md
@@ -74,7 +74,7 @@ parcel index.html about.html
 Use tokens and create a glob:
 
 ```bash
-parcel *.html
+parcel **/*.html
 ```
 
 _NOTE:_ In case you have a file structure like this:


### PR DESCRIPTION
With the current example using only `*.html` it doesnt find the html files inside folders.