### PR TITLE
Don't suggest using generateScopedName for css modules

### DIFF
--- a/src/languages/postcss.md
+++ b/src/languages/postcss.md
@@ -45,7 +45,7 @@ To change [postcss-modules options](https://github.com/css-modules/postcss-modul
 {% sample %}
 {% samplefile ".postcssrc" %}
 
-```json/1
+```json/4
 {
   "modules": true,
   "plugins": {

--- a/src/languages/postcss.md
+++ b/src/languages/postcss.md
@@ -32,6 +32,21 @@ There are two ways to enable CSS modules:
 
 ```json/1
 {
+  "modules": true
+}
+```
+
+{% endsamplefile %}
+{% endsample %}
+
+To change [postcss-modules options](https://github.com/css-modules/postcss-modules#usage), pass them via `plugins`:
+
+
+{% sample %}
+{% samplefile ".postcssrc" %}
+
+```json/1
+{
   "modules": true,
   "plugins": {
     "postcss-modules": {


### PR DESCRIPTION
I have a feeling that many people copy the first example for enabling PostCSS modules into their project and needlessly change `generateScopedName`.