### PR TITLE
Log the data (not the string "data") in Node Emulation example.

### DIFF
--- a/src/features/node-emulation.md
+++ b/src/features/node-emulation.md
@@ -64,7 +64,7 @@ import fs from "fs";
 import path from "path";
 
 const data = fs.readFileSync(path.join(__dirname, "data.json"), "utf8");
-console.log("data");
+console.log(data);
 ```
 
 {% endsamplefile %}


### PR DESCRIPTION
It may be nit-picky but the example on [the Node Emulation docs](https://v2.parceljs.org/features/node-emulation/#%F0%9F%8C%B3-environment-variables) is:

```
import fs from "fs";
import path from "path";

const data = fs.readFileSync(path.join(__dirname, "data.json"), "utf8");
console.log("data");
```

The last line logs the string "data" but I think it's more appropriate to log `data`.
So: `console.log(data)`