### PR TITLE
Use ISO date format in DOM; user prefence in UI

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -20,7 +20,9 @@ module.exports = function (eleventyConfig) {
 
   // Copy assets
   eleventyConfig.addPassthroughCopy("src/assets");
-  eleventyConfig.addPassthroughCopy({ "src/assets/favicon.ico": "favicon.ico" });
+  eleventyConfig.addPassthroughCopy({
+    "src/assets/favicon.ico": "favicon.ico",
+  });
 
   eleventyConfig.setTemplateFormats(["md", "css", "png", "svg"]);
   eleventyConfig.addWatchTarget("./api/");
@@ -45,8 +47,8 @@ module.exports = function (eleventyConfig) {
     return page.url;
   });
 
-  eleventyConfig.addFilter("toDate", function (date) {
-    return `${date.getDate()}.${date.getMonth() + 1}.${date.getFullYear()}`;
+  eleventyConfig.addFilter("toISODate", function (date) {
+    return date.toISOString().replace(/T.*/, "");
   });
 
   eleventyConfig.addPairedShortcode("note", function (content) {

--- a/src/_includes/layout.njk
+++ b/src/_includes/layout.njk
@@ -105,9 +105,10 @@
           <p class="summary">
             <span>{{ summary }}</span>
             {% if date %}
-            <span style="float: right;">
-              📆 {{ date | toDate }} {% endif %}
-            </span>
+            <time datetime="{{ date | toISODate }}" class="entry-date js-replace-date">
+              {{ date | toISODate }}
+            </time>
+            {% endif %}
           </p>
         </header>
 
@@ -120,6 +121,10 @@
         </footer>
       </div>
     </main>
+
+    <script>
+      {% include "replace-date.js" %}
+    </script>
 
     <script>
       document

--- a/src/_includes/replace-date.js
+++ b/src/_includes/replace-date.js
@@ -1,0 +1,29 @@
+"use strict";
+(function () {
+  const replaceElements = document.querySelectorAll(
+    "time[datetime].js-replace-date"
+  );
+
+  if (replaceElements.length === 0) {
+    return;
+  }
+
+  const lang = navigator.languages.length
+    ? navigator.languages
+    : document.documentElement.lang;
+
+  const dateFormatter = new Intl.DateTimeFormat(lang, {
+    year: "numeric",
+    month: "numeric",
+    day: "numeric",
+  });
+
+  Array.prototype.forEach.call(replaceElements, function (elem) {
+    try {
+      const date = Date.parse(elem.dateTime);
+      elem.innerHTML = dateFormatter.format(date);
+    } catch (e) {
+      // skip
+    }
+  });
+})();

--- a/src/doc-styles.scss
+++ b/src/doc-styles.scss
@@ -861,3 +861,11 @@ body {
     }
   }
 }
+
+.entry-date {
+  float: right;
+
+  &::before {
+    content: "📆\00a0";
+  }
+}


### PR DESCRIPTION
As an American and fan of ISO8601 living in a country using the Buddhist calendar, I'm quite aware of dates and ambiguity and frustration in formatting. Like Google giving me Buddhist years, and this blog using British format, it's just not helping me read this or understand dates at a glance -- especially in the context of a big, globally consumed library.

The purpose of this merge request is to use ISO formatted dates in the appropriate `<time>` element and then use the user's preferred numeric date representation in the UI (falling back through their other desired languages and finally to the document language). So if the user set their locale to `en-US` they will get month-date-year, and if they're locale is set to Thai, they will see the Buddhist year, and separator like `/` vs `.` vs `-` are whatever the default is. I'm open to doing a bit less magic, and passing in an empty array into the `Intl.DateTimeFormat` to get the browser default which could pull from the OS but might pull from the version of the browser downloaded but the downloaded browser may have had the wrong (or more likely default) language 🤷‍. Also open to filtering the `navigator.languages` `startsWith("en")` to get something closer that matches the document language, `"en"`. Lastly, I'm open to skipping any magic and always showing the ISO date instead.

Also the date emoji being cosmetic was moved to the `::before` content.