### PR TITLE
Add vis editor tip for hot module reloading

### DIFF
--- a/src/features/hmr.md
+++ b/src/features/hmr.md
@@ -58,5 +58,6 @@ When using Hot Module Reload (HMR) this feature blocks the automatic detection o
 - IntelliJ: use search in the preferences to find "safe write" and disable it.
 - Vim: add `:set backupcopy=yes` to your settings.
 - WebStorm: uncheck `Use "safe write"` in Preferences > Appearance & Behavior > System Settings.
+- vis: add `:set savemethod inplace` to your settings.
 
 (This functionality is provided by `@parcel/runtime-browser-hmr`.)


### PR DESCRIPTION
Hot module reloading was failing before I set this option.

See this discussion: https://github.com/martanne/vis/issues/938