### PR TITLE
Change App from element to component

### DIFF
--- a/src/recipes/react.md
+++ b/src/recipes/react.md
@@ -69,7 +69,7 @@ import React from "react";
 import ReactDom from "react-dom";
 import Component from "./Component.js";
 
-const App = (
+const App = () => (
   <h1>
     <Component />
   </h1>
@@ -115,7 +115,7 @@ import Component, { utility } from "./Component.js";
 
 console.log(utility());
 
-const App = (
+const App = () => (
   <h1>
     <Component />
   </h1>


### PR DESCRIPTION
In those examples, `App` is used as components (`render(<App />)`) and not as elements (`render(App)`), but is still defined as elements and not components

Before | After
-|-
![image](https://user-images.githubusercontent.com/22725671/112741126-e545a800-8f82-11eb-9d71-e67eaf69f2c1.png) |![image](https://user-images.githubusercontent.com/22725671/112741136-f7bfe180-8f82-11eb-9593-fe7247123362.png)
![image](https://user-images.githubusercontent.com/22725671/112741131-ee367980-8f82-11eb-9019-8056187a11b4.png) | ![image](https://user-images.githubusercontent.com/22725671/112741138-00181c80-8f83-11eb-8638-6ad4229f2d45.png)

