### PR TITLE
fix: true is not valid posthtml plugin config

### DIFF
--- a/src/languages/html.md
+++ b/src/languages/html.md
@@ -149,7 +149,7 @@ Then, create a config file:
 {% endsamplefile %}
 {% endsample %}
 
-Plugins are specified in the plugins object as keys, and options are defined using object values. If there are no options for a plugin, just set it to `true` or an empty object instead, another example:
+Plugins are specified in the plugins object as keys, and options are defined using object values. If there are no options for a plugin, just set it to an empty object instead, another example:
 
 {% sample %}
 {% samplefile ".posthtmlrc" %}


### PR DESCRIPTION
Only the empty object works. See https://github.com/parcel-bundler/parcel/issues/3156.