### PR TITLE
Remove a dynamic import tree shaking syntax

### DIFF
--- a/src/features/code-splitting.md
+++ b/src/features/code-splitting.md
@@ -83,13 +83,6 @@ let { x: y } = await import("./b.js");
 
 {% endsamplefile %}
 
-{% samplefile %}
-
-```js
-({ x } = await import("./b.js"));
-```
-
-{% endsamplefile %}
 
 {% samplefile %}
 


### PR DESCRIPTION
~Will be~ Was dropped with swc, and was brittle anyway