### PR TITLE
Rename --out-dir into --dist-dir 

### DIFF
--- a/src/i18n/en/docs/cli.md
+++ b/src/i18n/en/docs/cli.md
@@ -69,9 +69,7 @@ Default: "dist"
 Available in: `serve`, `watch`, `build`
 
 ```bash
-parcel build entry.js --out-dir build/output
-# or
-parcel build entry.js -d build/output
+parcel build entry.js --dist-dir build/output
 ```
 
 ```base

--- a/src/i18n/fr/docs/cli.md
+++ b/src/i18n/fr/docs/cli.md
@@ -69,9 +69,7 @@ Par défaut : "dist"
 Disponible dans : `serve`, `watch`, `build`
 
 ```bash
-parcel build entry.js --out-dir build/output
-# ou
-parcel build entry.js -d build/output
+parcel build entry.js --dist-dir build/output
 ```
 
 ```base

--- a/src/i18n/it/docs/cli.md
+++ b/src/i18n/it/docs/cli.md
@@ -43,9 +43,7 @@ Default: "dist"
 Disponibile in: `serve`, `watch`, `build`
 
 ```bash
-parcel build entry.js --out-dir build/output
-or
-parcel build entry.js -d build/output
+parcel build entry.js --dist-dir build/output
 ```
 
 ```base

--- a/src/i18n/ja/docs/cli.md
+++ b/src/i18n/ja/docs/cli.md
@@ -69,9 +69,7 @@ parcel --version
 利用可能: `serve`, `watch`, `build`
 
 ```bash
-parcel build entry.js --out-dir build/output
-# or
-parcel build entry.js -d build/output
+parcel build entry.js --dist-dir build/output
 ```
 
 ```base

--- a/src/i18n/ko/docs/cli.md
+++ b/src/i18n/ko/docs/cli.md
@@ -51,9 +51,7 @@ parcel --version
 같이 사용 가능한 명령어: `serve`, `watch`, `build`
 
 ```bash
-parcel build entry.js --out-dir build/output
-# 혹은
-parcel build entry.js -d build/output
+parcel build entry.js --dist-dir build/output
 ```
 
 ```base

--- a/src/i18n/pt/docs/cli.md
+++ b/src/i18n/pt/docs/cli.md
@@ -69,9 +69,7 @@ Padrão: "dist"
 Disponível em: `serve`, `watch`, `build`
 
 ```bash
-parcel build entry.js --out-dir build/output
-# ou
-parcel build entry.js -d build/output
+parcel build entry.js --dist-dir build/output
 ```
 
 ```base

--- a/src/i18n/ru/docs/cli.md
+++ b/src/i18n/ru/docs/cli.md
@@ -52,9 +52,7 @@ parcel --version
 Доступно для: `serve`, `watch`, `build`
 
 ```bash
-parcel build entry.js --out-dir build/output
-# or
-parcel build entry.js -d build/output
+parcel build entry.js --dist-dir build/output
 ```
 
 ```base

--- a/src/i18n/uk/docs/cli.md
+++ b/src/i18n/uk/docs/cli.md
@@ -52,9 +52,7 @@ parcel --version
 Доступно для: `serve`,`watch`, `build`
 
 ```Bash
-parcel build entry.js --out-dir build/output
-#або
-parcel build entry.js -d build/output
+parcel build entry.js --dist-dir build/output
 ```
 
 ```Base

--- a/src/i18n/zh-tw/docs/cli.md
+++ b/src/i18n/zh-tw/docs/cli.md
@@ -69,9 +69,7 @@ parcel --version
 適用指令： `serve`、`watch` 及 `build`
 
 ```bash
-parcel build entry.js --out-dir build/output
-# 或
-parcel build entry.js -d build/output
+parcel build entry.js --dist-dir build/output
 ```
 
 ```base

--- a/src/i18n/zh/docs/cli.md
+++ b/src/i18n/zh/docs/cli.md
@@ -69,9 +69,7 @@ parcel --version
 可用于：`serve`，`watch`，`build`
 
 ```bash
-parcel build entry.js --out-dir build/output
-# 或者
-parcel build entry.js -d build/output
+parcel build entry.js --dist-dir build/output
 ```
 
 ```base


### PR DESCRIPTION
The documentation was not changed, so fixed it.
https://v2.parceljs.org/getting-started/migration/#--out-dir

Thanks!

```bash
$ parcel --version
2.0.0-beta.2
$ parcel help build
Usage: parcel build [options] [input...]

bundles for production

Options:
  --no-optimize              disable minification
  --no-scope-hoist           disable scope-hoisting
  --public-url <url>         the path prefix for absolute urls
  --no-content-hash          disable content hashing
  --no-cache                 disable the filesystem cache
  --config <path>            specify which config to use. can be a path or a package name
  --cache-dir <path>         set the cache directory. defaults to ".parcel-cache"
  --no-source-maps           disable sourcemaps
  --target [name]            only build given target(s) (default: [])
  --log-level <level>        set the log level (choices: "none", "error", "warn", "info", "verbose")
  --dist-dir <dir>           output directory to write to when unspecified by targets
  --no-autoinstall           disable autoinstall
  --profile                  enable build profiling
  -V, --version              output the version number
  --detailed-report [count]  print the asset timings and sizes in the build report (default: "10")
  --reporter <name>          additional reporters to run (default: [])
  -h, --help                 display help for command
```