### PR TITLE
Fix TypeScript resolution example

### DIFF
--- a/src/features/module-resolution.md
+++ b/src/features/module-resolution.md
@@ -185,7 +185,7 @@ TypeScript will need to know about your use of the `~` module resolution or alia
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "~*": ["./src/*"]
+      "~*": ["./*"]
     }
   }
 }


### PR DESCRIPTION
`~` resolves to the project root which is a level higher than `src` (see https://v2.parceljs.org/features/module-resolution/#tilde-paths).