### PR TITLE
Update preact module resolution example

### DIFF
--- a/src/i18n/en/docs/module_resolution.md
+++ b/src/i18n/en/docs/module_resolution.md
@@ -51,8 +51,8 @@ This example aliases `react` to `preact` and some local custom module that is no
     "parcel-bundler": "^1.7.0"
   },
   "alias": {
-    "react": "preact-compat",
-    "react-dom": "preact-compat",
+    "react": "preact/compat",
+    "react-dom": "preact/compat",
     "local-module": "./custom/modules"
   }
 }


### PR DESCRIPTION
preact compact is now under the main preact package as `preact/compat`.