### PR TITLE
TypeScript support declaration is misleading

### DIFF
--- a/src/languages/typescript.md
+++ b/src/languages/typescript.md
@@ -7,7 +7,7 @@ eleventyNavigation:
 summary: Explains the different ways TypeScript can be transpiled
 ---
 
-Typescript works out of the box with Parcel, but you have multiple options:
+TypeScript type checking doesn't work. Only transpiling is supported, but you have multiple options:
 
 ## Babel
 


### PR DESCRIPTION
Only transpiling is supported. TypeScript is all about typings not transpiling. People expect that some toolkit elements have same behaviour without knowledge whats under the hood if you ignore typings it works in diffrent way that in the rest of ecosystem.