### PR TITLE
add compilerOptions in tsc's default configuration

### DIFF
--- a/src/languages/typescript.md
+++ b/src/languages/typescript.md
@@ -65,7 +65,11 @@ Neither the Babel transformer nor the tsc transformer perform type checking, the
 
 ```json
 {
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "compilerOptions": {
+    "target": "es2021",
+    "strict": true  
+  }
 }
 ```
 


### PR DESCRIPTION
If no target are defined, default will be E3 which is quite outdated.
For example, E3 does not recognize Map.