### PR TITLE
Update Elm sample.

### DIFF
--- a/src/languages/elm.md
+++ b/src/languages/elm.md
@@ -16,7 +16,7 @@ The npm package `elm` needs to be manually installed beforehand. You'll also nee
 ```html
 <!DOCTYPE html>
 <div id="root"></div>
-<script src="index.js"></script>
+<script type="module" src="index.js"></script>
 ```
 
 {% endsamplefile %}


### PR DESCRIPTION
I tested this minimal sample, but it requires `type="module"` to import Elm module on `index.js`.

Without `type="module"`:

```
🚨 Build failed.

@parcel/transformer-js: Browser scripts cannot have imports or exports.

  /***/parcel2-elm-test/src/index.js:1:1
  > 1 | import { Elm } from "./Main.elm";
  >   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    2 |
    3 | Elm.Main.init({ node: document.getElementById("root") });

  /***/parcel2-elm-test/src/index.html:3:1
    2 | <div id="root"></div>
  > 3 | <script src="index.js"></script>
  >   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ The environment was originally created here

  💡 Add the type="module" attribute to the <script> tag.
```