### PR TITLE
Correct the casing of "Webpack"

### DIFF
--- a/src/features/scope-hoisting.md
+++ b/src/features/scope-hoisting.md
@@ -102,7 +102,7 @@ console.log(other.x);
 
 ## Motivation and Advantages of Scope Hoisting
 
-For a long time, many bundlers (like Webpack and Browserify, but not Rollup) achieved the actual bundling by wrapping all assets in a function, creating a map of all included assets and providing a CommonJS runtime. A (very) simplified example of that:
+For a long time, many bundlers (like webpack and Browserify, but not Rollup) achieved the actual bundling by wrapping all assets in a function, creating a map of all included assets and providing a CommonJS runtime. A (very) simplified example of that:
 
 ```js
 (function (modulesMap, entry) {

--- a/src/languages/babel.md
+++ b/src/languages/babel.md
@@ -8,7 +8,7 @@ eleventyNavigation:
 
 ## Dependencies
 
-To retrieve the final (and hashed) URL of assets (images, videos, ...), you can either use `new URL("file.mp4", import.meta.url)` (which is the recommended way as it also works in modern browsers without bundling and because it's also picked up by Webpack):
+To retrieve the final (and hashed) URL of assets (images, videos, ...), you can either use `new URL("file.mp4", import.meta.url)` (which is the recommended way as it also works in modern browsers without bundling and because it's also picked up by webpack):
 
 {% sample %}
 {% samplefile %}

--- a/src/languages/vue.md
+++ b/src/languages/vue.md
@@ -54,7 +54,7 @@ app.mount("#app");
 
 ## HMR
 
-Parcel uses the same HMR injection as the official [vue-loader](https://github.com/vuejs/vue-loader) for Webpack, so you'll have a fast, reactive development experience.
+Parcel uses the same HMR injection as the official [vue-loader](https://github.com/vuejs/vue-loader) for webpack, so you'll have a fast, reactive development experience.
 
 ## Vue 3 Features
 

--- a/src/recipes/react.md
+++ b/src/recipes/react.md
@@ -6,7 +6,7 @@ eleventyNavigation:
   order: 3
 ---
 
-Compared to Webpack, Parcel's paradigm is to use your HTML file as the entry point, not merely the main script:
+Compared to webpack, Parcel's paradigm is to use your HTML file as the entry point, not merely the main script:
 
 {% sample "parcel index.html" %}
 {% samplefile "index.html" %}


### PR DESCRIPTION
According to: https://webpack.js.org/branding/#the-name