### PR TITLE
Fix typo in recepies/react.md

### DIFF
--- a/src/recipes/react.md
+++ b/src/recipes/react.md
@@ -41,7 +41,7 @@ Most Parcel apps start with an HTML file. Parcel follows the dependencies (such 
 
 ```jsx
 import ReactDOM from "react-dom";
-import App from "./App";
+import { App } from "./App";
 
 const app = document.getElementById("app");
 ReactDOM.render(<App />, app);


### PR DESCRIPTION
Named export should be used to correctly import App component.