### PR TITLE
More docs for .parcelrc, plugin config loading, and Transformers

### DIFF
--- a/src/configuration/plugin-configuration.md
+++ b/src/configuration/plugin-configuration.md
@@ -1,69 +1,206 @@
 ---
 layout: layout.njk
+title: Parcel configuration
 eleventyNavigation:
   key: configuration-plugin-configuration
   title: 🔌 Parcel configuration
   order: 1
-summary: How to use plugins and create named pipelines
 ---
 
-Parcel is designed to be very modular, `@parcel/core` itself is (almost) not specific to bundling Javascript or Webpages. To actually specify the behaviour, there are different plugins (see [Plugin System](/plugin-system/overview)).
+Parcel works out of the box for many projects with zero configuration. But if you want more control, or need to extend or override Parcel’s defaults, you can do so by creating a `.parcelrc` file in your project.
 
-Here is an excerpt from the default config that the `parcel` CLI uses. Generally, there are three categories of plugin types (with regards to the configuration):
+Parcel is designed to be very modular. Parcel core itself is almost not specific to building JavaScript or web pages – all behavior is specified via plugins. There are specific plugin types for each phase of a build, so you can customize just about everything.
 
-- only one plugin for the whole build (bundler)
-- a list of plugins that run sequentially (namers/resolvers/reporters)
-- the plugin(s) are specified per asset/bundle type (transformers/packagers/optimizers)
-- runtimes are the exception here, because they are specified per [context](/getting-started/configuration/#targets-2).
+## `.parcelrc`
+
+Parcel configuration is specified in a `.parcelrc` file. It is written in [JSON5](https://json5.org), which is similar to JSON but supports comments, unquoted keys, trailing commas, and other features.
+
+### Extending configs
+
+Parcel’s default config is specified in `@parcel/config-default`. Most of the time, you'll want to extend it in your own Parcel config. To do this, use the `extends` field in your `.parcelrc`.
 
 {% sample %}
 {% samplefile ".parcelrc" %}
 
-```json/3,14,17
+```json
 {
-  "bundler": "@parcel/bundler-default",
-  "transformers": {
-    "*.{js,jsx,ts,tsx}": [
-      "@parcel/transformer-babel",
-      "@parcel/transformer-js"
-    ],
-    "url:*": ["@parcel/transformer-raw"]
-  },
-  "namers": ["@parcel/namer-default"],
-  "runtimes": {
-    "browser": ["@parcel/runtime-js", "@parcel/runtime-browser-hmr"],
-    "service-worker": ["@parcel/runtime-js"],
-    "web-worker": ["@parcel/runtime-js"],
-    "node": ["@parcel/runtime-js"]
-  },
-  "optimizers": {
-    "*.js": ["@parcel/optimizer-terser"]
-  },
-  "packagers": {
-    "*.html": "@parcel/packager-html",
-    "*": "@parcel/packager-raw"
-  },
-  "resolvers": ["@parcel/resolver-default"],
-  "reporters": ["@parcel/reporter-cli"]
+  "extends": "@parcel/config-default"
 }
 ```
 
 {% endsamplefile %}
 {% endsample %}
 
-A filetype is specified by a glob which is matched against the _whole filepath_ (the _pipelines_ are matched in order of declaration), so you could use different plugins depending on the input/output filepath:
-
-- The globs for transformers are matched against the asset (input) path.
-- The globs for packagers and optimizers are matched against the bundle (output) path.
-
-### Extending configs
-
-A common usecase is extending the default config, for this reason the `extends` field can be a config package or an array of config packages to extend.
+You may also extend multiple configs by passing an array. Configs are merged in the order they are specified.
 
 {% sample %}
 {% samplefile ".parcelrc" %}
 
-```json/1
+```json
+{
+  "extends": ["@parcel/config-default", "@company/parcel-config"]
+}
+```
+
+{% endsamplefile %}
+{% endsample %}
+
+You can also reference another config in your project using a relative path.
+
+{% sample %}
+{% samplefile ".parcelrc" %}
+
+```json
+{
+  "extends": "../.parcelrc"
+}
+```
+
+{% endsamplefile %}
+{% endsample %}
+
+Extended configs may also extend other configs, which forms a config chain.
+
+### Glob maps
+
+Many fields in `.parcelrc` like `transformers` or `packagers` use objects as maps of globs to plugin names. This lets you configure Parcel’s behavior by file extension, file path, or even a specific file name. Globs are matched relative to the directory containing the `.parcelrc`.
+
+The order of fields in glob maps maps defines their priority when a file name is being tested against them. This lets you configure different behavior for certain files within your project, such as files in a specific directory.
+
+{% sample %}
+{% samplefile ".parcelrc" %}
+
+```json
+{
+  "transformers": {
+    "icons/*.svg": ["highest-priority"],
+    "*.svg": ["lowest-priority"]
+  }
+}
+```
+
+{% endsamplefile %}
+{% endsample %}
+
+Here if we are trying to find a transform for the file `icons/home.svg`, we'll work our way down the globs until we find a match, which would be `icons/*.svg`. We never reach `*.svg`.
+
+Once all of the globs in the current config are checked, Parcel falls back to the globs defined in any extended configs.
+
+### Pipelines
+
+Many fields in `.parcelrc` like `transformers`, `optimizers`, and `reporters` accept an array of plugins which run in series. These are called **pipelines**.
+
+If you’d like to define a higher priority pipeline that extends a lower priority one rather than overriding it, you can use the special `"..."` syntax to do so. Add this within a pipeline to embed the next priority pipeline within it. You can insert it at the beginning, end, or even in the middle of a pipeline, which gives you full control over how pipelines are extended.
+
+{% sample %}
+{% samplefile ".parcelrc" %}
+
+```json
+{
+  "transformers": {
+    "icons/*.svg": ["@company/parcel-transformer-svg-icons", "..."],
+    "*.svg": ["@parcel/transformer-svg"]
+  }
+}
+```
+
+{% endsamplefile %}
+{% endsample %}
+
+In the above example, when processing `icons/home.svg`, we first run `@company/parcel-transformer-svg-icons` and then `@parcel/transformer-svg`.
+
+This also applies to configs that have been extended. If a  `"..."` is used and there are no lower priority pipelines defined in the current config, Parcel falls back to pipelines defined in the extended configs.
+
+Since `@parcel/transformer-svg` is included in the default config, the above example could be rewritten like this:
+
+{% sample %}
+{% samplefile ".parcelrc" %}
+
+```json
+{
+  "extends": "@parcel/config-default",
+  "transformers": {
+    "icons/*.svg": ["@company/parcel-transformer-svg-icons", "..."]
+  }
+}
+```
+
+{% endsamplefile %}
+{% endsample %}
+
+### Named pipelines
+
+In addition to glob-based pipelines, Parcel supports **named pipelines**, which enable you to import a the same file in multiple ways. Named pipelines are defined in `.parcelrc` just like normal pipelines, but include a URL scheme at the start of the glob.
+
+For example, by default, importing an image normally returns a URL to an external file, but you could use the `data-url:` named pipeline defined in the default Parcel config to inline it as a data URL instead. See [Bundle inlining](/features/bundle-inlining/) for details.
+
+{% sample %}
+{% samplefile "src/example.css" %}
+
+```css
+.logo {
+  background: url(data-url:./logo.png);
+}
+```
+
+{% endsamplefile %}
+{% endsample %}
+
+You can also define your own named pipelines. For example, you could define an `arraybuffer:` named pipeline that allows you to import a file as an [ArrayBuffer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer). The `*` glob matches any file in this example, but you could also use a more-specific glob. The `"..."` syntax is used to allow Parcel to process the file as it normally would before running the `parcel-transformer-arraybuffer` plugin to convert it to an ArrayBuffer.
+
+{% sample %}
+{% samplefile ".parcelrc" %}
+
+```json
+{
+  "extends": "@parcel/config-default",
+  "transformers": {
+    "arraybuffer:*": ["...", "parcel-transformer-arraybuffer"]
+  }
+}
+```
+
+{% endsamplefile %}
+{% samplefile "src/example.js" %}
+
+```javascript
+import buffer from 'arraybuffer:./file.png';
+```
+
+{% endsamplefile %}
+{% endsample %}
+
+Named pipelines are supported for transformer and optimizer pipelines. For transformers, the pipeline is specified in the dependency that referenced the asset. For optimizers, it is inherited from the entry asset of the bundle.
+
+## Plugins
+
+Parcel supports many different kinds of plugins which perform a specific task as part of your build. Plugins are referenced in your `.parcelrc` using their NPM package names.
+
+### Transformers
+
+[Transformer](/plugin-system/transformer/) plugins transform a single asset to compile it, discover dependencies, or convert it to a different format. They are configured using a [glob map](#glob-maps) in `.parcelrc`. Multiple transformers may run in series over the same asset using [pipelines](#pipelines), and [named pipelines](#named-pipelines) are supported to allow compiling the same file in multiple different ways within the same project. The `"..."` syntax can be used to extend the default transformers for a file.
+
+{% sample %}
+{% samplefile ".parcelrc" %}
+
+```json
+{
+  "extends": "@parcel/config-default",
+  "transformers": {
+    "*.svg": ["...", "@parcel/transformer-svg-react"]
+  }
+}
+```
+
+{% endsamplefile %}
+{% endsample %}
+
+When compiling an asset, its file type may change. For example, when compiling TypeScript, the asset’s type changes from `ts` or `tsx` to `js`. When this happens, Parcel re-evaluates how the asset should be further processed, and runs it through the matching pipeline for `.js` files.
+
+{% sample %}
+{% samplefile ".parcelrc" %}
+
+```json
 {
   "extends": "@parcel/config-default",
   "transformers": {
@@ -75,44 +212,114 @@ A common usecase is extending the default config, for this reason the `extends` 
 {% endsamplefile %}
 {% endsample %}
 
-To add additional plugins without overwriting the default ones, add `"..."` to use the plugins provided by the config specified in the `extends` field. For example to add another reporter:
-
-{% sample %}
-{% samplefile ".parcelrc" %}
-
-```json/1
-{
-  "extends": "@parcel/config-default",
-  "reporters": ["...", "parcel-reporter-custom"]
-}
-```
-
-{% endsamplefile %}
-{% endsample %}
-
-
-### Pipelines
-
-The observant reader might have noticed that the last config example didn't include `@parcel/transformer-js`, which is required for `@parcel/runtime-js` and `@parcel/runtime-packager`.
-
-This is solved with _pipelines_. A Typescript asset is first processed by the `ts` pipeline and once the `@parcel/transformer-typescript-tsc` plugin sets the asset type (which is essentially equivalent to the file extension) to `js`, Parcel reevaluates how the asset should be further processed. In this case, it will be put into the `js` pipeline specified in `@parcel/config-default`. This way, `@parcel/transformer-js` will still be executed.
-
 {% warning %}
 
-Once a transformer sets the asset type to a type that is not covered by the current pipeline, the asset wil either be put into a different pipeline or transformation is finished. _Transformers that should still be run afterwards according the current pipeline will not be run._
+Once a transformer changes the asset type so that it no longer matches the current pipeline, the asset will be put into a different pipeline. If there is no matching pipeline for the new asset type, then transformation is finished. Transformers defined later in the current pipeline will not be run.
 
 {% endwarning %}
 
-If a transformer doesn't change the asset type and you still want to continue processing this asset, add `"..."` to continue the transformation (in an extended config). This can be useful if you want to modify an asset without changing its type and let an already-defined pipeline handle the translation/dependency registration.
+### Resolvers
 
-{% sample  %}
+[Resolver](/plugin-system/resolver/) plugins are responsible for turning a dependency specifier into a full file path that will be processed by transformers. See [Dependency resolution](/features/dependency-resolution/) for details on how this works. Resolvers are configured using an array of plugin names in `.parcelrc`. Resolution proceeds through the list of plugins until one of them returns a result.
+
+The `"..."` syntax can be used to extend the default resolvers. This allows you to override the resolution for certain dependencies, but fall back to the default for others. Generally, you'll want to add your custom resolvers before running the default ones.
+
+{% sample %}
 {% samplefile ".parcelrc" %}
 
-```json/3
+```json
 {
   "extends": "@parcel/config-default",
-  "transformers": {
-    "*.js": ["parcel-transformer-add-comment", "..."]
+  "resolvers": ["@company/parcel-resolver", "..."]
+}
+```
+
+{% endsamplefile %}
+{% endsample %}
+
+If `"..."` is omitted, your resolver must be able to handle all dependencies or resolution will fail.
+
+### Bundler (experimental)
+
+A [Bundler](/plugin-system/bundler/) plugin is responsible for grouping assets together into bundles. The bundler can be configured by specifying a plugin name in `.parcelrc`.
+
+{% sample %}
+{% samplefile ".parcelrc" %}
+
+```json
+{
+  "extends": "@parcel/config-default",
+  "bundler": "@company/parcel-bundler"
+}
+```
+
+{% endsamplefile %}
+{% endsample %}
+
+{% warning %}
+
+**Note**: Bundler plugins are experimental, and subject to change, even between minor updates.
+
+{% endwarning %}
+
+### Runtimes (experimental)
+
+[Runtime](/plugin-system/runtime/) plugins allow you to inject assets into bundles. They can be configured using an array of plugin names in `.parcelrc`. All runtime plugins in this list are run over each bundle. The `"..."` syntax can be used to extend the default runtimes.
+
+{% sample %}
+{% samplefile ".parcelrc" %}
+
+```json
+{
+  "extends": "@parcel/config-default",
+  "runtimes": ["@company/parcel-runtime", "..."]
+}
+```
+
+{% endsamplefile %}
+{% endsample %}
+
+If `"..."` is omitted, the default runtimes will not be run. This will probably break things, as many Parcel features rely on the default runtimes.
+
+{% warning %}
+
+**Note**: Runtime plugins are experimental, and subject to change, even between minor updates.
+
+{% endwarning %}
+
+### Namers
+
+[Namer](/plugin-system/namer/) plugins determine the output filename for a bundle. They are configured using an array of plugin names in `.parcelrc`. Naming proceeds through the list of namers until one of them returns a result.
+
+The `"..."` syntax can be used to extend the default namers. This allows you to override naming of certain bundles, but fall back to the default for others. Generally, you'll want to add your custom namers before running the default ones.
+
+{% sample %}
+{% samplefile ".parcelrc" %}
+
+```json
+{
+  "extends": "@parcel/config-default",
+  "namers": ["@company/parcel-namer", "..."]
+}
+```
+
+{% endsamplefile %}
+{% endsample %}
+
+If `"..."` is omitted, your namer must be able to handle naming all bundles or the build will fail.
+
+### Packagers
+
+[Packager](/plugin-system/packager/) plugins are responsible for combining all of the assets in a bundle together into an output file. They are configured using a [glob map](#glob-maps) in `.parcelrc`. Globs are matched against the output filename of a bundle. A single packager plugin may be configured to run per bundle.
+
+{% sample %}
+{% samplefile ".parcelrc" %}
+
+```json
+{
+  "extends": "@parcel/config-default",
+  "packagers": {
+    "*.{jpg,png}": "@company/parcel-packager-image-sprite"
   }
 }
 ```
@@ -120,119 +327,145 @@ If a transformer doesn't change the asset type and you still want to continue pr
 {% endsamplefile %}
 {% endsample %}
 
-### Named Pipelines
+### Optimizers
 
-In addition to the asset type-based pipelines, there are _named pipelines_, which enable you to import a single asset type in different ways (e.g. formats).
+[Optimizer](/plugin-system/optimizer/) plugins are similar to transformers but they accept a bundle instead of a single asset. They are configured using a [glob map](#glob-maps) in `.parcelrc`. Multiple optimizers may run in series over the same bundle using [pipelines](#pipelines), and [named pipelines](#named-pipelines) are supported to allow compiling the same bundle in multiple different ways within the same project. The `"..."` syntax can be used to extend the default optimizers for a bundle.
 
-Named pipelines are specified using a procotol-like syntax, e.g. `import myLogo from "url:./logo.png";`
-
-Here is an example on how you achieve a url dependency that doesn't create a new bundle but is rather inlined as a data url.
-
-{% sample undefined, "column" %}
+{% sample %}
 {% samplefile ".parcelrc" %}
 
-(_Note: this config is already contained in `@parcel/config-default`. This config is just for illustration._)
-
-```json/3,6
+```json
 {
   "extends": "@parcel/config-default",
-  "transformers": {
-    "data-url:*": ["@parcel/transformer-inline-string", "..."]
-  },
   "optimizers": {
-    "data-url:*": ["...", "@parcel/optimizer-data-url"]
+    "*.js": ["@parcel/optimizer-esbuild"]
   }
 }
 ```
 
 {% endsamplefile %}
-{% samplefile "index.js" %}
-
-```js/2
-import x from "./other.js";
-
-new Worker("data-url:./worker.js");
-
-// ...
-```
-
-{% endsamplefile %}
 {% endsample %}
 
-As you can see, `...` is now used to make sure that `data-url:./worker.js` will still be processed with the `js` pipeline (the named pipeline specifier only applies for the first pipeline match).
+### Compressors
 
-{% note %}
-
-If you're curious how this can be achieved without a deeper integration with Parcel core:
-
-`@parcel/transformer-inline-string` marks the asset as an inlined asset. `@parcel/packager-js` then inlines this inline bundle (as a string `"${contents}"`). This inline bundle was previously processed by `@parcel/optimizer-data-url`, which encoded the JavaScript code into a data url.
-
-{% endnote %}
-
-Named pipelines are currently implemented for transformers and optimizers (the named pipeline is inheirited from the entry asset).
-
-#### Predefined (offical) named pipelines
-
-- `data-url:` See above for an example. It isn't replaced with a URL to a new bundle but instead with an isolated data url.
-- `url:` Needed when e.g. importing "normal" assets such as media files as a URL
+[Compressor](/plugin-system/compressor/) plugins are used when writing a final bundle to disk and may compress or encode it in some way (e.g. Gzip). They are configured using a [glob map](#glob-maps) in `.parcelrc`. Multiple compressors may run over the same bundle using [pipelines](#pipelines). Each compressor plugin produces an additional file to be written in parallel, for example `bundle.js`, `bundle.js.gz` and `bundle.js.br`. The `"..."` syntax can be used to extend the default compressors for a bundle.
 
 {% sample %}
-{% samplefile "index.js" %}
+{% samplefile ".parcelrc" %}
 
-```js/0
-import logo from "url:./logo.svg";
-
-document.body.innerHTML = `<img src="${logo}">`;
-```
-
-{% endsamplefile %}
-{% endsample %}
-
-{% note %}
-
-You might ask why we chose to use this explicit syntax. The reason is that this way, adding a new asset type to Parcel isn't a breaking change anymore (this happened in the past when `import foo from "./other.html"` didn't return the URL anymore, but rather the HTML contents).
-
-It's also possible to modify the parcel config to opt into the old behaviour: see [Migration](/getting-started/migration/#importing-non-code-assets-from-javascript).
-
-{% endnote %}
-
-- `bundle-text:` Can be used to e.g. import a CSS (or LESS!) file's contents into Javascript (needed for some "frameworks")
-
-{% sample %}
-{% samplefile "style.less" %}
-
-```less
-@myColor: #143352;
-
-span {
-  color: @myColor;
-}
-```
-
-{% endsamplefile %}
-{% samplefile "index.js" %}
-
-```js/0,9
-import style from "bundle-text:./logo.less";
-
-class MyTest extends HTMLElement {
-  constructor() {
-    super();
-
-    let shadow = this.attachShadow({ mode: "open" });
-
-    let styleSheet = document.createElement("style");
-    styleSheet.textContent = style;
-    shadow.appendChild(styleSheet);
-
-    let info = document.createElement("span");
-    info.textContent = this.getAttribute("label");
-    shadow.appendChild(info);
+```json
+{
+  "extends": "@parcel/config-default",
+  "compressors": {
+    "*.{js,html,css}": [
+      "...",
+      "@parcel/compressor-gzip", 
+      "@parcel/compressor-brotli"
+    ]
   }
 }
-
-customElements.define("my-test", MyTest);
 ```
 
 {% endsamplefile %}
 {% endsample %}
+
+### Reporters
+
+[Reporter](/plugin-system/reporter/) plugins receive events from Parcel as they happen throughout the build process. For example, reporters may write status information to stdout, run a dev server, or generate a bundle analysis report at the end of a build. Reporters are configured using an array of package names in `.parcelrc`. All reporters in this list are run for each build event. The `"..."` syntax can be used to extend the default reporters.
+
+{% sample %}
+{% samplefile ".parcelrc" %}
+
+```json
+{
+  "extends": "@parcel/config-default",
+  "reporters": ["...", "@parcel/reporter-bundle-analyzer"]
+}
+```
+
+{% endsamplefile %}
+{% endsample %}
+
+Reporters that you use infrequently may also be specified on the [CLI](/features/cli/) using the `--reporter` option, or via the [API](/features/parcel-api/) using the `additionalReporters` option. Reporters specified in `.parcelrc` always run.
+
+## Local plugins
+
+Parcel plugins are NPM packages. This means they have a `package.json` which declares the version of Parcel they are compatible with, along with any dependencies they may have. They must also follow a naming system to ensure clarity.
+
+Usually, Parcel plugins are published to the NPM registry, or to an internal company registry (e.g. Artifactory). This encourages plugins to be shared with the community or across projects within your company to avoid duplication.
+
+However, when developing a plugin, it can be useful to run it directly in your project without publishing it first. There are a few ways of doing this.
+
+#### Yarn and NPM workspaces
+
+One way is to use a monorepo setup via [Yarn Workspaces](https://classic.yarnpkg.com/en/docs/workspaces/) or [NPM Workspaces](https://docs.npmjs.com/cli/v7/using-npm/workspaces). This allows you to depend on other packages within your repo the same way you depend on published packages. To do this, set up a project structure like this:
+
+```
+project
+├── .parcelrc
+├── package.json
+└── packages
+    ├── app
+    │   └── package.json
+    └── parcel-transformer-foo
+        ├── package.json
+        └── src
+            └── FooTransformer.js
+```
+
+In your root `package.json`, use the `workspaces` field to reference your packages.
+
+{% sample %}
+{% samplefile "package.json" %}
+
+```json
+{
+  "name": "my-project",
+  "private": true,
+  "workspaces": ["packages/*"]
+}
+```
+
+{% endsamplefile %}
+{% endsample %}
+
+Then, in your `.parcelrc` you can reference `parcel-transformer-foo` as you would a published package. Whenever you update the code for your plugin, Parcel will rebuild your project.
+
+You can also choose to keep your app in the root (e.g. in a `src` folder) rather than inside `packages/app`.
+
+#### The `link:` protocol
+
+Yarn supports defining dependencies using the `link:` protocol to reference local directories as packages. For example, you could set up a project structure like this:
+
+```
+project
+├── .parcelrc
+├── package.json
+├── src
+│   └── index.html
+└── parcel-transformer-foo
+    ├── package.json
+    └── src
+        └── FooTransformer.js
+```
+
+In your root package.json, you can define a dependency on the `parcel-transformer-foo` package using the `link:` protocol.
+
+{% sample %}
+{% samplefile "package.json" %}
+
+```json
+{
+  "name": "my-project",
+  "dependencies": {
+    "parcel": "^2.0.0",
+    "parcel-transformer-foo": "link:./parcel-transformer-foo"
+  }
+}
+```
+
+{% endsamplefile %}
+{% endsample %}
+
+Then, in your `.parcelrc` you can reference `parcel-transformer-foo` as you would a published package. Whenever you update the code for your plugin, Parcel will rebuild your project.
+

--- a/src/plugin-system/transformer.md
+++ b/src/plugin-system/transformer.md
@@ -4,38 +4,271 @@ eleventyNavigation:
   key: plugin-system-transformer
   title: Transformer
   order: 3
-summary: "A plugin type: Convert an asset (into another asset)"
 ---
 
-Transformers _transform_ single assets as they are discovered and added to the
-asset graph. They mostly call out to different compilers and preprocessors.
+Transformer plugins transform a single asset to compile it, discover dependencies, or convert it to a different format. Many transformers are wrappers around other tools such as compilers and preprocessors, and are responsible for integrating them with Parcel.
 
-```js
-import { Transformer } from "@parcel/plugin";
+## Transforming assets
+
+There is one required function that must be passed to the [`Transformer`](#Transformer) constructor: `transform`. This function receives a [`MutableAsset`](#MutableAsset) object, which represents a file. The source code or content of the asset can be retrieved, along with any associated source map. The transformer can then transform this content in some way, and set the compiled result back on the asset.
+
+```javascript
+import {Transformer} from '@parcel/plugin';
 
 export default new Transformer({
-  async canReuseAST({ ast, options, logger }) {
-    return false;
-  },
+  async transform({asset}) {
+    // Retrieve the asset's source code and source map.
+    let source = await asset.getCode();
+    let sourceMap = await asset.getMap();
 
-  async loadConfig({ config, options, logger }) {
-    // ...
-    return config;
-  },
+    // Run it through some compiler, and set the results 
+    // on the asset.
+    let {code, map} = compile(source, sourceMap);
+    asset.setCode(code);
+    asset.setMap(map);
 
-  async parse({ asset, config, logger, resolve, options }) {
-    // ...
-    return ast;
-  },
+    // Return the asset
+    return [asset];
+  }
+});
+```
 
-  async transform({ asset, config, logger, resolve, options }) {
-    // ...
+## Loading configuration
+
+Loading configuration from the user’s project should be done in the `loadConfig` method of a Transformer plugin. See [Loading configuration](/plugin-system/authoring-plugins#loading-configuration) for details on how to do this.
+
+{% warning %}
+
+**Note**: It's important to use Parcel's config loading mechanism so that the cache can be properly invalidated. Avoid loading files directly from the file system.
+
+{% endwarning %}
+
+## Changing the asset type
+
+Transformers may transform an asset from one format to another, for example from TypeScript to JavaScript. To do this, set the asset's `type` property to the new file type (e.g. `js`). The asset will then be processed by the pipeline matching the new type. See [Transformers](/configuration/plugin-configuration/#transformers) in the Parcel configuration docs for details.
+
+```javascript/7
+import {Transformer} from '@parcel/plugin';
+
+export default new Transformer({
+  async transform({asset}) {
+    let code = await asset.getCode();
+
+    let result = compile(code);
+    asset.type = 'js';
+    asset.setCode(result);
+
+    return [asset];
+  }
+});
+```
+
+## The environment
+
+Assets are associated with an [`Environment`](/plugin-system/api/#Environment), which describes the how the asset should be compiled. The same asset may be processed multiple times with different environments, for example, when building for modern and legacy targets. If possible, Transformer plugins should take the environment into account when compiling code to ensure that the result works in and is optimized for the target. See [Targets](/features/targets/) for details.
+
+```javascript/6-8
+import {Transformer} from '@parcel/plugin';
+
+export default new Transformer({
+  async transform({asset}) {
+    let code = await asset.getCode();
+
+    let result = asset.env.isBrowser()
+      ? compileForBrowser(code, asset.engines.browser)
+      : compileForNode(code, asset.engines.node);
+
+    asset.setCode(result);
+    return [asset];
+  }
+});
+```
+
+See the [`Environment`](/plugin-system/api/#Environment) API docs for details on the available properties.
+
+## Adding dependencies
+
+In addition to transforming the contents of an asset, Transformer plugins are also responsible for discovering dependencies in the code so that they may also be processed by Parcel. Some transformers don’t need to worry about this, because another transformer will run afterward and do it (e.g. the default JavaScript transformer). If you’re adding support for a new language that doesn’t compile to one of the existing languages supported by Parcel, or otherwise introduces dependencies outside the compiled code, you’ll need to add them to the asset.
+
+Dependencies can be added to an asset using the `addDependency` method, passing a [`DependencyOptions`](#DependencyOptions) object. There are two required parameters: `specifier`, which is a string describing the location of the dependency, and `specifierType`, which describes how the specifier should be interpreted. See [Dependency resolution](/features/dependency-resolution/) for details.
+
+```javascript/8-11
+import {Transformer} from '@parcel/plugin';
+
+export default new Transformer({
+  async transform({asset}) {
+    let code = await asset.getCode();
+    let deps = code.matchAll(/import "(.*?)"/g);
+    
+    for (let dep of deps) {
+      asset.addDependency({
+        specifier: dep,
+        specifierType: 'esm'
+      });
+    }
+
+    return [asset];
+  }
+});
+```
+
+### Influencing bundling
+
+The way a dependency is specified can influence how it is bundled. By default, dependencies are bundled together into the same output file. The `priority` property of a dependency can specify that it should be loaded lazily or in parallel with the asset that depends on it. For example, dynamic `import()` in JavaScript loads dependencies with the `lazy` priority. See [Code splitting](/features/code-splitting/).
+
+The `bundleBehavior` property further controls how a dependency is bundled. For example, dependencies may be separated into a new bundle but inlined into the parent by setting `bundleBehavior` to `inline`. See [Bundle inlining](/features/bundle-inlining/).
+
+See [`DependencyOptions`](#DependencyOptions) for more details on each of the available options.
+
+### URL dependencies
+
+In some languages, dependencies reference other files by URL. In the compiled code, these URL references will need to be updated to point to the final bundle names. However, when an asset is being transformed, bundle names will not yet be known.
+
+`addDependency` returns a unique dependency ID. This can be placed in the transformed asset content as a placeholder for the final bundle URL, and it will be replaced later by a Packager once the URL is known.
+
+As a shortcut, the `addURLDependency` method creates a dependency with `specifierType` set to `url`, and `priority` set to `lazy` (to create a separate bundle).
+
+```javascript/9-10
+import {Transformer} from '@parcel/plugin';
+
+export default new Transformer({
+  async transform({asset}) {
+    let code = await asset.getCode();
+    let result = code.replace(/import "(.*?)"/g, (m, dep) => {
+      // Replace the original specifier with a dependency id 
+      // as a placeholder. This will be replaced later with 
+      // the final bundle URL.
+      let depId = asset.addURLDependency(dep);
+      return `import "${depId}"`;
+    });
+
+    asset.setCode(result);
+    return [asset];
+  }
+});
+```
+
+## Reusing ASTs
+
+If multiple Transformer plugins run in series over an asset, it would be wasteful to parse, transform, and code generate for each one if they could reuse the same parsed AST. Parcel facilitates AST sharing by splitting the `transform` function into several parts:
+
+- `canReuseAST` – If an AST is available from a previous Transformer plugin, it will be passed to this method on the next Transformer if available. It should inspect the `type` and `version` of the AST to determine if it can reuse it. If it returns `true`, then the `parse` method is not called and the AST is reused. If it returns `false`, then the previous Transformer's `generate` function is called, and the next Transformer's `parse` function is called with the results.
+- `parse` – If an AST is not available, or `canReuseAST` returned false, then the Transformer's `parse` function is called. It should return an [`AST`](/plugin-system/api/#AST) object describing the type, version, and contents of the AST.
+- `generate` – If the next Transformer cannot reuse the AST, or this is the last Transformer in a pipeline, `generate` will be called with the AST object. A result object containing generated content and a source map should be returned.
+
+```javascript
+import {Transformer} from '@parcel/plugin';
+import semver from 'semver';
+
+export default new Transformer({
+  async canReuseAST({ast}) {
+    return ast.type === 'my-compiler' 
+      && semver.satisfies(ast.version, '^1.0.0');
+  },
+  async parse({asset}) {
+    return {
+      type: 'my-compiler',
+      version: '1.0.0',
+      program: parse(await asset.getCode())
+    };
+  },
+  async transform({asset}) {
+    let ast = await asset.getAST();
+
+    let compiledAST = compile(ast.program);
+    asset.setAST({
+      type: 'my-compiler',
+      version: '1.0.0',
+      program: compiledAST
+    });
+
     return [asset];
   },
+  async generate({ast}) {
+    let {content, map} = generate(ast.program);
+    return {
+      content,
+      map
+    };
+  }
+});
+```
 
-  async generate({ asset, ast, resolve, options }) {
-    // ...
-    return { code, map };
+## Binary data
+
+In addition to textual source code, Transformers can handle binary content. This can be done either by using a [Buffer](https://nodejs.org/api/buffer.html), or using [streams](https://nodejs.org/api/stream.html).
+
+```javascript/4,7
+import {Transformer} from '@parcel/plugin';
+
+export default new Transformer({
+  async transform({asset}) {
+    let buffer = await asset.getBuffer();
+
+    let result = transform(buffer);
+    asset.setBuffer(result);
+
+    return [asset];
+  }
+});
+```
+
+## Query parameters
+
+An asset may be referenced by a dependency with [query parameters](/features/dependency-resolution/#query-parameters). These specify options for the transformer to use when compiling or transforming the asset. For example, the Parcel [image transformer](/recipes/image/) uses query parameters to allow users to specify the width, height, and format to convert images to. The same asset may be compiled multiple times with different query parameters.
+
+```javascript/8-9
+import {Transformer} from '@parcel/plugin';
+
+export default new Transformer({
+  async transform({asset}) {
+    let buffer = await asset.getBuffer();
+
+    let result = resize(
+      buffer,
+      asset.query.width,
+      asset.query.height
+    );
+
+    asset.setBuffer(result);
+    return [asset];
+  }
+});
+```
+
+## Returning multiple assets
+
+All of the examples so far have shown how to transform a single asset. However, sometimes a file may contain multiple different assets. For example, in HTML there are inline `<script>` and `<style>` elements that should be processed through their own separate Parcel pipelines. For this, Parcel allows returning multiple assets from a transformer.
+
+To create new assets, return an array of [`TransformerResult`](#TransformerResult) objects. These must have a `type` and `content`, but may also have dependencies of their own, as well as many of the same options that `Asset` objects have.
+
+Usually, the original asset should be returned in addition to any child assets it may have. The parent can create dependencies on the children by assigning them a `uniqueKey` property and referencing that as the `specifier` of a dependency. This allows creating "virtual" assets that don't really exist on the file system, but may be referenced like they are.
+
+```javascript
+import {Transformer} from '@parcel/plugin';
+
+export default new Transformer({
+  async transform({asset}) {
+    let code = await asset.getCode();
+
+    // Extract inline assets to return in addition to this asset.
+    let assets = [asset];
+
+    let uniqueKey = `${asset.id}-style`;
+    assets.push({
+      type: 'css',
+      content: '...',
+      uniqueKey,
+      bundleBehavior: 'inline'
+    });
+
+    // Add a dependency, using the uniqueKey as a specifier.
+    asset.addDependency({
+      specifier: uniqueKey,
+      specifierType: 'esm'
+    });
+
+    return assets;
   }
 });
 ```


### PR DESCRIPTION
* Updates Parcel configuration page to add more details on each plugin type
* Adds a section covering the `loadConfig` method of most plugin types
* Adds more docs and example for Transformers