### PR TITLE
Fix public url of prod builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "license": "MIT",
   "scripts": {
-    "build": "rm -rf _site dist; eleventy; parcel build _site/index.html '_site/*/*/*.html' --public-url https://${VERCEL_URL:-v2.parceljs.org}",
+    "build": "rm -rf _site dist; eleventy; parcel build _site/index.html '_site/*/*/*.html' --public-url $(node public-url.js)",
     "watch": "eleventy --watch",
     "serve": "parcel _site/index.html '_site/*/*/*.html'",
     "start": "run-p watch serve",

--- a/public-url.js
+++ b/public-url.js
@@ -1,0 +1,11 @@
+switch (process.env.VERCEL_ENV) {
+  case 'production':
+    process.stdout.write('https://v2.parceljs.org');
+    break;
+  case 'preview':
+    process.stdout.write('https://' + process.env.VERCEL_URL);
+    break;
+  default:
+    process.stdout.write('/');
+    break;
+}


### PR DESCRIPTION
I guess `VERCEL_URL` isn't actually the prod url but the url of the deployment so we also need to check `VERCEL_ENV`.