### PR TITLE
Include default resolver in glob import example

### DIFF
--- a/src/features/dependency-resolution.md
+++ b/src/features/dependency-resolution.md
@@ -176,7 +176,7 @@ Parcel supports importing multiple files at once via globs, however, since glob 
 ```json
 {
   "extends": "@parcel/config-default",
-  "resolvers": ["@parcel/resolver-glob", "..."]
+  "resolvers": ["@parcel/resolver-default", "@parcel/resolver-glob"]
 }
 ```
 


### PR DESCRIPTION
It wasn't immediately obvious why my build broke when I copied the `.parcelrc` content from this example, but including the default resolver fixed it. Updating the docs so it's more obvious and copy/paste-able