### PR TITLE
Fix broken links on Production page

### DIFF
--- a/src/features/cli.md
+++ b/src/features/cli.md
@@ -47,7 +47,7 @@ See [Production](/features/production/) for more details.
 
 ## Entries
 
-All Parcel commands accept one or more entries. Entries may be relative or absolute paths, or globs. They may also be directories containing a `package.json` with a `source` field. If entries are omitted entirely, the `source` field in the `package.json` in the current working directory is used. See [Entries](/features/targes/#entries) in the Targets documentation for more details.
+All Parcel commands accept one or more entries. Entries may be relative or absolute paths, or globs. They may also be directories containing a `package.json` with a `source` field. If entries are omitted entirely, the `source` field in the `package.json` in the current working directory is used. See [Entries](/features/targets/#entries) in the Targets documentation for more details.
 
 {% warning %}
 

--- a/src/features/production.md
+++ b/src/features/production.md
@@ -23,7 +23,7 @@ Parcel includes minifiers for JavaScript, CSS, HTML, and SVG out of the box. Min
 
 By default, minification is enabled when using the `parcel build` command. You can use the `--no-optimize` CLI flag to disable minification and other optimizations if needed.
 
-Parcel uses [terser](https://github.com/fabiosantoscode/terser) to minify JavaScript, [cssnano](http://cssnano.co/) for CSS, [htmlnano](https://github.com/posthtml/htmlnano) for HTML, and [svgo](https://github.com/svg/svgo) for SVG. If needed, you can configure these tools using a `.terserrc`, `.cssnanorc`, `.htmlnanorc`, or `svgo.config.json` config file. See the docs for [JavaScript](/languages/babel/), [CSS](/languages/postcss/), [HTML](/languages/html), and [SVG](/languages/svg/) for more details.
+Parcel uses [terser](https://github.com/fabiosantoscode/terser) to minify JavaScript, [cssnano](http://cssnano.co/) for CSS, [htmlnano](https://github.com/posthtml/htmlnano) for HTML, and [svgo](https://github.com/svg/svgo) for SVG. If needed, you can configure these tools using a `.terserrc`, `.cssnanorc`, `.htmlnanorc`, or `svgo.config.json` config file. See the docs for [JavaScript](/languages/javascript/), [CSS](/languages/css/), [HTML](/languages/html), and [SVG](/languages/svg/) for more details.
 
 ### Tree shaking
 


### PR DESCRIPTION
I noticed these two links were broken clicking around on the current hosted docs.