### PR TITLE
Fix includeNodeModules example in targets.md

### DIFF
--- a/src/features/targets.md
+++ b/src/features/targets.md
@@ -274,7 +274,7 @@ Determines whether to bundle `node_modules` or treat them as external. The defau
   {
     "targets": {
       "main": {
-        "includeNodeModules" ["react"]
+        "includeNodeModules": ["react"]
       }
     }
   }


### PR DESCRIPTION
Fixed the lack of semicolon in json file example.