### PR TITLE
Fix typos: “programatically” => “programmatically”

### DIFF
--- a/src/home/scalable.html
+++ b/src/home/scalable.html
@@ -22,7 +22,7 @@
     </section>
     <section class="col-span-4 sm:col-span-2 xl:col-span-1 flex flex-col p-5 md:p-10 bg-gradient-to-tr from-rose-300 to-orange-300 dark:from-rose-700 dark:to-pink-800 rounded-xl" style="background-size: 200% 100%">
       <h4 class="text-xl font-semibold text-orange-800 dark:text-orange-300 mb-4">API</h4>
-      <p class="flex-grow mb-8 max-w-4xl text-lg lg:text-xl font-medium text-gray-800 dark:text-orange-100">Integrate Parcel into any existing build system using Parcel's API, which allows you to perform builds programatically.</p>
+      <p class="flex-grow mb-8 max-w-4xl text-lg lg:text-xl font-medium text-gray-800 dark:text-orange-100">Integrate Parcel into any existing build system using Parcel's API, which allows you to perform builds programmatically.</p>
       <a class="block text-lg font-medium text-orange-900 dark:text-orange-200 hover:underline" href="/features/parcel-api/">Learn more →</a>
     </section>
     <section class="col-span-4 sm:col-span-2 xl:col-span-1 p-5 md:p-10 bg-gradient-to-tr from-rose-300 to-orange-300 dark:from-rose-700 dark:to-pink-800 rounded-xl" style="background-size: 200% 100%; background-position: right top">

--- a/src/plugin-system/overview.md
+++ b/src/plugin-system/overview.md
@@ -73,7 +73,7 @@ separate bundles. For example, if your `index.html` file links to an
   _Example: create a bundler that does vendoring (splitting app and node_modules code)_
 - [Namer](/plugin-system/namer): Generates a filename (or filepath) for a bundle <br>
   _Example: place output bundles in a hierarchical file structure, omit hashes in bundle names_
-- [Runtime](/plugin-system/runtime): Programatically inserts (synthetic) assets into bundles" <br>
+- [Runtime](/plugin-system/runtime): Programmatically inserts (synthetic) assets into bundles" <br>
   _Example: add analytics to every bundle_
 - [Packager](/plugin-system/packager): Turns a group of assets (bundle) into a bundle file" <br>
   _Example: concatenate all input CSS files into a CSS bundle_

--- a/src/plugin-system/runtime.md
+++ b/src/plugin-system/runtime.md
@@ -4,7 +4,7 @@ eleventyNavigation:
   key: plugin-system-runtime
   title: Runtime
   order: 7
-summary: "A plugin type: Programatically insert assets out of thin air into bundles"
+summary: "A plugin type: Programmatically insert assets out of thin air into bundles"
 ---
 
 {% warning %}


### PR DESCRIPTION
Congrats on the release. Website is gorgeous and the tool looks so mature now! Excited to try it out.