### PR TITLE
Fix getting-started/library.md

### DIFF
--- a/src/getting-started/library.md
+++ b/src/getting-started/library.md
@@ -115,7 +115,7 @@ Parcel accepts both CommonJS and ES modules as input, and can output one or more
 
 Now Parcel will output `dist/main.js` as a CommonJS module, and `dist/module.js` as an ES module. Tools that consume your library will choose whichever of these they support.
 
-You can also use the file extension to indicate what type of module to output. The `.mjs` extension will produce an ES module, and the `.cjs` extension will produce an ES module. This overrides the default behavior of the `main` field. The `"type": "module"` field can also be set in package.json to treat the `main` field as an ES module as well. See the [Node.js docs](https://nodejs.org/dist/latest-v16.x/docs/api/packages.html#packages_determining_module_system) for more details.
+You can also use the file extension to indicate what type of module to output. The `.mjs` extension will produce an ES module, and the `.cjs` extension will produce a CommonJS module. This overrides the default behavior of the `main` field. The `"type": "module"` field can also be set in package.json to treat the `main` field as an ES module as well. See the [Node.js docs](https://nodejs.org/dist/latest-v16.x/docs/api/packages.html#packages_determining_module_system) for more details.
 
 ## TypeScript
 

--- a/src/getting-started/library.md
+++ b/src/getting-started/library.md
@@ -60,7 +60,7 @@ export function add(a, b) {
 
 Now, our library exports a single function called `add`, which adds its two parameters together and returns the result. Since this is written in ES module syntax using the `export` keyword, Parcel will compile our code to a CommonJS module as expected by default in the `main` field.
 
-To build our library, run `parcel build` within the project directory. Parcel will build your source code and output a JavaScript file in `dist/main.js` as referenced by the `main` field.
+To build our library, run `npx parcel build` within the project directory. Parcel will build your source code and output a JavaScript file in `dist/main.js` as referenced by the `main` field.
 
 ## Package scripts
 


### PR DESCRIPTION
- Fix "command not found: parcel" error when parcel is NOT installed globally
- Fix typo