### PR TITLE
Mention the option to disable image optimization in docs

### DIFF
--- a/src/recipes/image.md
+++ b/src/recipes/image.md
@@ -126,3 +126,22 @@ You can also define more advanced options per format. All images in formats with
 ## Image optimization
 
 Parcel also includes lossless image optimization for JPEGs and PNGs by default in production mode, which reduces the size of images without affecting their quality. This does not require any query parameters or configuration to use. However, since the optimization is lossless, the size reduction possible may be less than if you use the `quality` query param, or use a modern format such as WebP or AVIF.
+
+## Disabling image optimization
+
+To disable the default image optimization for JPEGs and PNGs in production mode, add the following to your .parcelrc configuration file:
+
+{% sample %}
+{% samplefile ".parcelrc" %}
+
+```json
+{
+  "extends": "@parcel/config-default",
+  "optimizers": {
+    "*.{jpg,jpeg,png}": []
+  }
+}
+```
+
+{% endsamplefile %}
+{% endsample %}


### PR DESCRIPTION
I added a note at the end of the image recipe page, which explains how to disable the image optimization, (useful for people who are doing the image optimization themselves for some reason)