### PR TITLE
vue: add type="module" for v2

### DIFF
--- a/src/languages/vue.md
+++ b/src/languages/vue.md
@@ -23,7 +23,7 @@ eleventyNavigation:
 ```html
 <!DOCTYPE html>
 <div id="app"></div>
-<script src="./index.js"></script>
+<script type="module" src="./index.js"></script>
 ```
 
 {% endsamplefile %}


### PR DESCRIPTION
Hi,

This example wasn't working for parcel v2.
We just need to follow https://parceljs.org/getting-started/migration/#%3Cscript-type%3D%22module%22%3E 