### PR TITLE
include required CLI command for --bundle-node-modules

### DIFF
--- a/src/getting-started/migration.md
+++ b/src/getting-started/migration.md
@@ -395,6 +395,7 @@ parcel build index.js --no-scope-hoist
 
 ### `--bundle-node-modules`
 
+Note: this CLI option does not exist for Parcel 2.
 To bundle packages from `node_modules` when targetting Node.js, you now should specify that in the target configuration:
 
 {% migration %}
@@ -406,6 +407,10 @@ parcel build index.js --target node --bundle-node-modules
 
 {% endsamplefile %}
 {% samplefile "package.json" %}
+
+```bash
+parcel build index.js --target default
+```
 
 ```json5/3,7
 {


### PR DESCRIPTION
Added the `--target default` example because without it parcel 2 gives the extremely unhelpful message of 

```
🚨 Build failed.

Error: Bundles must have unique names

  AssertionError [ERR_ASSERTION]: Bundles must have unique names
  at BundlerRunner.nameBundles (/Users/jeffhykin/repos/vibrance/node_modules/@parcel/core/lib/requests/BundleGraphRequest.js:343:23)
  at processTicksAndRejections (node:internal/process/task_queues:94:5)
  at async BundlerRunner.bundle (/Users/jeffhykin/repos/vibrance/node_modules/@parcel/core/lib/requests/BundleGraphRequest.js:286:5)
  at async RequestTracker.runRequest (/Users/jeffhykin/repos/vibrance/node_modules/@parcel/core/lib/RequestTracker.js:721:20)
  at async Object.run (/Users/jeffhykin/repos/vibrance/node_modules/@parcel/core/lib/requests/ParcelBuildRequest.js:62:7)
  at async RequestTracker.runRequest (/Users/jeffhykin/repos/vibrance/node_modules/@parcel/core/lib/RequestTracker.js:721:20)
  at async Parcel._build (/Users/jeffhykin/repos/vibrance/node_modules/@parcel/core/lib/Parcel.js:397:11)
  at async Parcel.run (/Users/jeffhykin/repos/vibrance/node_modules/@parcel/core/lib/Parcel.js:275:18)
  at async run (/Users/jeffhykin/repos/vibrance/node_modules/parcel/lib/cli.js:374:7)
```