### PR TITLE
Typo fix in graphl fragment docs

### DIFF
--- a/src/languages/graphql.md
+++ b/src/languages/graphql.md
@@ -65,7 +65,7 @@ query UserQuery($id: ID) {
   user(id: $id) {
     ...UserFragment
     address {
-      ...Address
+      ...AddressFragment
     }
   }
 }


### PR DESCRIPTION
Took me a minute to grok this example since the fragment name in the query did not match the one in the `address.graphql` file.