### PR TITLE
fix: Typo for closing </h1> in React recipes

### DIFF
--- a/src/recipes/react.md
+++ b/src/recipes/react.md
@@ -396,7 +396,7 @@ export function Home() {
 
   return (
     <main>
-      <h1>Home<h1>
+      <h1>Home</h1>
       <button onClick={() => setShowProfile(true)}>
         Show Profile
       </button>


### PR DESCRIPTION
Just a simple fix for a typo :)

