### PR TITLE
Use `fetchDataQuery` instead of test in GQL example in migration.md

### DIFF
--- a/src/getting-started/migration.md
+++ b/src/getting-started/migration.md
@@ -271,7 +271,7 @@ When import GraphQL files (`.gql`), imports are still resolved/inlined (using `g
 import fetchDataQuery from "./fetchData.gql"; // fetchDataQuery is the parsed AST
 
 const DataComponent = () => {
-  const { data } = useQuery(test, {
+  const { data } = useQuery(fetchDataQuery, {
     fetchPolicy: "cache-and-network",
   });
 


### PR DESCRIPTION
I noticed that in the code in parcel 1, we are using the word `test` in `useQuery`

![image](https://user-images.githubusercontent.com/22725671/150582535-41b9f6b0-882c-4a55-aebd-49706232aa54.png)


But in parcel 2 example, we use the return of the `gql()` function

![image](https://user-images.githubusercontent.com/22725671/150582597-8f15f99d-6224-4b94-a562-0874bdc027f0.png)


I think that `test` is a mistake and that it should also be `fetchDataQuery`

---

Try it out: https://website-git-fork-ayc0-patch-1-devongovett.vercel.app/getting-started/migration/#importing-graphql