### PR TITLE
Update Tailwind CSS recipe

### DIFF
--- a/src/recipes/react.md
+++ b/src/recipes/react.md
@@ -277,7 +277,6 @@ Next, create the config files needed for PostCSS and Tailwind. This example will
 
 ```javascript
 module.exports = {
-  mode: "jit",
   content: ["./src/*.{html,js}"],
   theme: {
     extend: {},


### PR DESCRIPTION
With the launch of Tailwind CSS v3.0 the JIT mode is [turned-on by default](https://tailwindcss.com/blog/tailwindcss-v3#just-in-time-all-the-time).