### PR TITLE
Use `devDependencies` instead of `dependencies`

### DIFF
--- a/src/getting-started/migration.md
+++ b/src/getting-started/migration.md
@@ -33,7 +33,7 @@ The first thing to note when upgrading from Parcel 1 to Parcel 2 is that the npm
 
 ```json/2
 {
-  "dependencies": {
+  "devDependencies": {
     "parcel": "^2.0.0"
   }
 }

--- a/src/getting-started/migration.md
+++ b/src/getting-started/migration.md
@@ -22,7 +22,7 @@ The first thing to note when upgrading from Parcel 1 to Parcel 2 is that the npm
 
 ```json/2
 {
-  "dependencies": {
+  "devDependencies": {
     "parcel-bundler": "^1.12.5"
   }
 }


### PR DESCRIPTION
`devDependencies` is used later in the same document:

https://github.com/parcel-bundler/website/blob/97792a0c81b5b4def7e2d31651cd2ce344bd9b1a/src/getting-started/migration.md?plain=1#L182-L184