### PR TITLE
fix Visual Studio Code debug instructions

### DIFF
--- a/src/recipes/debugging.md
+++ b/src/recipes/debugging.md
@@ -67,7 +67,8 @@ Assuming a folder/file structure similar to the one shown above for Chrome devel
       "webRoot": "${workspaceFolder}",
       "breakOnLoad": true,
       "sourceMapPathOverrides": {
-        "../*": "${webRoot}/*"
+        "../*": "${webRoot}/*",
+        "/__parcel_source_root/*": "${webRoot}/*"
       }
     }
   ]


### PR DESCRIPTION
Added a second `sourceMapPathOverrides` value to match current output of Parcel (see [this post on Reddit](https://www.reddit.com/r/learnjavascript/comments/sfowch/comment/hurc44w/?utm_source=share&utm_medium=web2x&context=3) for further reference).
Tested with Parcel 2.3.2 and Visual Studio Code 1.64.2