### PR TITLE
Correct specifiers to have extensions in vue example

### DIFF
--- a/src/languages/vue.md
+++ b/src/languages/vue.md
@@ -31,7 +31,7 @@ eleventyNavigation:
 
 ```jsx
 import { createApp } from "vue";
-import App from "./App";
+import App from "./App.vue";
 
 const app = createApp(App);
 app.mount("#app");
@@ -202,7 +202,7 @@ export default function (component, blockContent, blockAttrs) {
 </template>
 
 <script>
-  import Child from "./HomePage";
+  import Child from "./HomePage.vue";
   export default {
     components: {
       child: Child,


### PR DESCRIPTION
https://parceljs.org/features/dependency-resolution/#file-extensions says that extensionless *.vue file imports aren't allowed.