### PR TITLE
fix: plugin code example

### DIFF
--- a/src/plugin-system/packager.md
+++ b/src/plugin-system/packager.md
@@ -60,7 +60,7 @@ export default new Packager({
       promises.push(Promise.all([
         asset.getCode(),
         asset.getMap()
-      ]);
+      ]));
     });
 
     let assets = await Promise.all(promises);


### PR DESCRIPTION
### Problem

The code example in the [Source maps section of the plugin docs](https://parceljs.org/plugin-system/packager/#source-maps) is missing a closing parenthesis.

### Solution

Add the missing closing parenthesis.