### PR TITLE
Update getting_started.md

### DIFF
--- a/src/i18n/ko/docs/getting_started.md
+++ b/src/i18n/ko/docs/getting_started.md
@@ -7,13 +7,13 @@ Parcel`[파설, /parsəl/]`은 개발 경험에서 차이를 느낄수 있는 �
 Yarn:
 
 ```bash
-yarn global add parcel-bundler
+yarn add --dev parcel
 ```
 
 npm:
 
 ```bash
-npm install -g parcel-bundler
+npm install --save-dev parcel
 ```
 
 그 다음, package.json 파일을 프로젝트 디렉토리에 만드세요.


### PR DESCRIPTION
with the update to parcel v2, the cli for installing parcel changed to :
yarn add --dev parcel
npm install --save-dev parcel

however, korean documentation still uses cli for parcel v1:
npm install -g parcel-bundler
yarn global add parcel-bundler

so, I propose these changes to follow up with parcel v2.