### PR TITLE
Add GitHub link to the top right navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,15 @@ Start a local server using:
 
 ```bash
 yarn
+yarn build
 yarn serve
+```
+
+Start in a development mode using:
+
+```bash
+yarn
+yarn start
 ```
 
 The website is automatically deployed using [Vercel](https://vercel.com).

--- a/src/home/index.html
+++ b/src/home/index.html
@@ -63,7 +63,7 @@
           <div class="lg:mr-12">
             <div class="flex flex-row items-center">
               <h2 class="text-4xl md:text-5xl xl:text-6xl font-extrabold text-white my-5 lg:my-10 leading-tight">
-                The zero configuration build tool for 
+                The zero configuration build tool for
                 <ul id="languageMarquee" class="inline-block align-top relative z-0 whitespace-nowrap">
                   <li><span class="text-green-400">the web</span>.</li>
                   <li><span class="text-cyan-400">JavaScript</span>.</li>
@@ -105,7 +105,7 @@
                 #languageMarquee li:first-child {
                   transform: translateY(0);
                   opacity: 1;
-                  animation: 
+                  animation:
                     var(--animation-duration) fade-up-first 2650ms ease-in-out,
                     var(--animation-duration) fade-up calc(2650ms + var(--animation-duration)) ease-in-out infinite;
                 }
@@ -113,7 +113,7 @@
                 #languageMarquee li:last-child {
                   position: static;
                 }
-                
+
                 @keyframes fade-up {
                   0% {
                     opacity: 0;
@@ -217,7 +217,7 @@
               let file = filenames[Math.floor(Math.random() * filenames.length)];
               let time = Math.floor(Math.random() * 600) + 45;
               let spins = Math.floor(time / 80);
-              
+
               for (let i = 0; i < spins; i++) {
                 heroStatus.textContent = `${spinners[i % spinners.length]} Building ${file}...`;
                 await sleep(80);
@@ -268,6 +268,7 @@
         </div>
         <a href="/docs/" class="hover:text-pink-100 dark:hover:text-pink-200 transition">Docs</a>
         <a href="/blog/" class="hover:text-pink-100 dark:hover:text-pink-200 transition">Blog</a>
+        <a href="https://github.com/parcel-bundler/parcel" target="_blank" rel="noopener" class="hover:text-pink-100 dark:hover:text-pink-200 transition hidden md:block">GitHub</a>
       </nav>
     </header>
     <section class="pt-20 lg:pt-32 -mb-10 flex flex-row flex-wrap gap-x-10 gap-y-6 items-center justify-center max-w-xl lg:max-w-full mx-auto px-8 text-gray-700 dark:text-gray-300">


### PR DESCRIPTION
Hello dear maintainers!

I open Parcel website very very often and literally every time I want to go straight to GitHub to check issues or whatever I land in this kind of workflow:

1. Type parcel in Safari url
2. Safari autocompletes with Parcel website
3. I hit open, look for GitHub link in the upper right navigation
4. Nothing here... where is it?
5. Maybe in the footer?

I don't know the reason but my brain expects this link in the top right corner while this big fat GitHub button below the logo is not picked up by it (thanks, brain...).

I don't want to ask you to do changes like this because I know you have better things to do, so I prepared those changes and if you find it worth merging, I'd be very happy.

If not, I'll make my brain remember this link ain't there.

Cheers!

PS: sorry for those white spaces changes, I didn't pick them up. Don't know if my IDE or prettier does it on save.