### PR TITLE
Fixed PluginSearch page's badRequest error

### DIFF
--- a/src/plugin-browser/hooks.js
+++ b/src/plugin-browser/hooks.js
@@ -23,7 +23,6 @@ export function useSearch({ type, page, filter, includeOfficial }) {
           {
             analyticsTags: ["parcel-plugin-browser"],
             attributesToHighlight: ["name", "description", "keywords"],
-            restrictSearchableAttributes: ["_searchInternal.alternativeNames"],
             attributesToRetrieve: [
               "isDeprecated",
               "description",


### PR DESCRIPTION
### Fixed issue: #1042  The PluginSearch page cannot be displayed normally.
### Cause: A wrong request parameter.
 
1. "restrictSearchableAttributes: ["_searchInternal.alternativeNames"]". This parameter causes a 400 badRequest error.This error caused the page to fail to display search results;
2. I've tested in my local. After removing this parameter, the page will display normally.
3. I've just commented out the line and added a description.