### PR TITLE
Remove reference to nonfunctional third-party package

### DIFF
--- a/src/languages/elm.md
+++ b/src/languages/elm.md
@@ -106,8 +106,6 @@ Beware of 2 things:
 1. **Path base:** The paths given in the `with` param values are relative to the directory of the first file in the `import` statement (in this case `Main.elm`), NOT relative to the JS file that contains the `import` statement.
 2. **Unintentional Duplication:** Multiple imports that effectively specify the same Elm files but in a different order (or differ regarding leading `./`, etc.) are treated as different assets (and will therefore be duplicated)
 
-To avoid those pitfalls when making heavy use of `with` params (i.e. importing some combination in more than one place), it's recommended to use something like [this third-party resolver package](https://www.npmjs.com/package/parcel-resolver-elm-bundle) which allows specifying some shorthands for commonly used Elm file combinations.
-
 ## Time-travelling debugger
 
 Elm's debug mode is automatically enabled when not building for production (it is disabled automatically with `parcel build`). You can set the environment variable `PARCEL_ELM_NO_DEBUG=1` to disable it even in development mode.


### PR DESCRIPTION
I get  `@parcel/package-manager: Could not find module "parcel-resolver-elm-bundle", but it was listed in package.json. Run your package manager first.` whenever attempting to utilise the package recommended.

Removing so future developers don't lose as much hair as I did.