### PR TITLE
Initial docs for app profiling

### DIFF
--- a/src/features/cli.md
+++ b/src/features/cli.md
@@ -80,7 +80,7 @@ parcel
 These parameters are supported by all Parcel commands.
 
 | Format                                       | Description                                                                                                                                                        |
-| -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --- |
+| -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `--target [name]`                            | Specifies the targets to build. May be specified multiple times. See [Targets](/features/targets/).                                                                |
 | `--dist-dir <dir>`                           | Output directory to write to when unspecified by targets. <br> Default value for the [`distDir`](/features/targets/#distdir) option in package.json `targets`.     |
 | `--public-url <url>`                         | The path prefix for absolute urls. <br> Default value for the [`publicUrl`](/features/targets/#publicurl) option in package.json `targets`.                        |
@@ -89,7 +89,7 @@ These parameters are supported by all Parcel commands.
 | `--reporter <package name>`                  | Run the specified reporter plugin in addition to the ones specified in the `.parcelrc`. Can be specified multiple times.                                           |
 | `--log-level (none/error/warn/info/verbose)` | Sets the log level.                                                                                                                                                |
 | `--cache-dir <path>`                         | Sets the cache directory. Defaults to `.parcel-cache`. See [Caching](/features/development/#caching).                                                              |
-| `--no-cache`                                 | Disables reading from the filesystem cache. See [Caching](/features/development/#caching).                                                                         |     |
+| `--no-cache`                                 | Disables reading from the filesystem cache. See [Caching](/features/development/#caching).                                                                         |
 | `--profile`                                  | Runs a CPU Sampling profile during the build (a flamechart can be generated).                                                                                      |
 | `--profile-application`                      | Runs an [Application Profile](/features/profiling) during the build.                                                                                               |
 | `-V, --version`                              | Outputs the version number.                                                                                                                                        |
@@ -119,8 +119,8 @@ These parameters are supported by all Parcel commands.
 ### Parameters specific to `build`
 
 | Format                      | Description                                                                                                                                                                                      |
-| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --- |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `--no-optimize`             | Disables optimizations such as minification. <br> Overrides the [`optimize`](/features/targets/#optimize) option of package.json `targets`. See [Production](/features/production/).             |
 | `--no-scope-hoist`          | Disables scope hoisting. <br> Overrides the [`scopeHoist`](/features/targets/#scopehoist) option of package.json `targets`. See [Scope hoisting](/features/scope-hoisting/).                     |
-| `--no-content-hash`         | Disables content hashing of output file names. <br> Bundle names may still include hashes, but they will not change on each build. See [Content hashing](/features/production/#content-hashing). |     |
+| `--no-content-hash`         | Disables content hashing of output file names. <br> Bundle names may still include hashes, but they will not change on each build. See [Content hashing](/features/production/#content-hashing). |
 | `--detailed-report [depth]` | Displays the largest 10 (number configurable with `depth`) assets per bundle in the CLI report. See [Detailed report](/features/production/#detailed-report).                                    |

--- a/src/features/cli.md
+++ b/src/features/cli.md
@@ -91,7 +91,7 @@ These parameters are supported by all Parcel commands.
 | `--cache-dir <path>`                         | Sets the cache directory. Defaults to `.parcel-cache`. See [Caching](/features/development/#caching).                                                              |
 | `--no-cache`                                 | Disables reading from the filesystem cache. See [Caching](/features/development/#caching).                                                                         |
 | `--profile`                                  | Runs a CPU Sampling profile during the build (a flamechart can be generated).                                                                                      |
-| `--profile-application`                      | Runs an [Application Profile](/features/profiling) during the build.                                                                                               |
+| `--trace`                                    | Runs a [trace](/features/profiling) during the build.                                                                                                              |
 | `-V, --version`                              | Outputs the version number.                                                                                                                                        |
 
 ### Parameters specific to `serve` and `watch`

--- a/src/features/cli.md
+++ b/src/features/cli.md
@@ -79,47 +79,48 @@ parcel
 
 These parameters are supported by all Parcel commands.
 
-| Format                                       | Description                                                                                                                                  |
-| -------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--target [name]`                            | Specifies the targets to build. May be specified multiple times. See [Targets](/features/targets/). |
-| `--dist-dir <dir>`                           | Output directory to write to when unspecified by targets. <br> Default value for the [`distDir`](/features/targets/#distdir) option in package.json `targets`. |
-| `--public-url <url>`                         | The path prefix for absolute urls. <br> Default value for the [`publicUrl`](/features/targets/#publicurl) option in package.json `targets`.                     |
-| `--no-source-maps`                           | Disables sourcemaps, <br> Overrides the [`sourceMap`](/features/targets/#sourcemap) option in package.json `targets`.                                          |
+| Format                                       | Description                                                                                                                                                        |
+| -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --- |
+| `--target [name]`                            | Specifies the targets to build. May be specified multiple times. See [Targets](/features/targets/).                                                                |
+| `--dist-dir <dir>`                           | Output directory to write to when unspecified by targets. <br> Default value for the [`distDir`](/features/targets/#distdir) option in package.json `targets`.     |
+| `--public-url <url>`                         | The path prefix for absolute urls. <br> Default value for the [`publicUrl`](/features/targets/#publicurl) option in package.json `targets`.                        |
+| `--no-source-maps`                           | Disables sourcemaps, <br> Overrides the [`sourceMap`](/features/targets/#sourcemap) option in package.json `targets`.                                              |
 | `--config <path>`                            | Specify which Parcel config to use. <br> Can be a file path or package name. Defaults to `@parcel/config-default`. See [Parcel configuration](/features/plugins/). |
-| `--reporter <package name>`                  | Run the specified reporter plugin in addition to the ones specified in the `.parcelrc`. Can be specified multiple times.                                |
-| `--log-level (none/error/warn/info/verbose)` | Sets the log level.                                                                                                                           |
-| `--cache-dir <path>`                         | Sets the cache directory. Defaults to `.parcel-cache`. See [Caching](/features/development/#caching).
-| `--no-cache`                                 | Disables reading from the filesystem cache. See [Caching](/features/development/#caching).                                                                                                   |                                                                                        |
-| `--profile`                                  | Profiles the build (a flamechart can be generated).                                                                                           |
-| `-V, --version`                              | Outputs the version number.                                                                                                                   |
+| `--reporter <package name>`                  | Run the specified reporter plugin in addition to the ones specified in the `.parcelrc`. Can be specified multiple times.                                           |
+| `--log-level (none/error/warn/info/verbose)` | Sets the log level.                                                                                                                                                |
+| `--cache-dir <path>`                         | Sets the cache directory. Defaults to `.parcel-cache`. See [Caching](/features/development/#caching).                                                              |
+| `--no-cache`                                 | Disables reading from the filesystem cache. See [Caching](/features/development/#caching).                                                                         |     |
+| `--profile`                                  | Runs a CPU Sampling profile during the build (a flamechart can be generated).                                                                                      |
+| `--profile-application`                      | Runs an [Application Profile](/features/profiling) during the build.                                                                                               |
+| `-V, --version`                              | Outputs the version number.                                                                                                                                        |
 
 ### Parameters specific to `serve` and `watch`
 
-| Format              | Description                                                                           |
-| ------------------- | ------------------------------------------------------------------------------------- |
-| `-p, --port <port>` | The port for the dev server and HMR (the default port is `process.env.PORT` or 1234). See [Dev server](/features/development/#dev-server).  |
-| `--host <host>`     | Sets the host to listen on, defaults to listening on all interfaces                   |
-| `--https`           | Runs the dev server and HMR server over [HTTPS](/features/development/#https).        |
-| `--cert <path>`     | Path to a certificate to use. See [HTTPS](/features/development/#https).              |
-| `--key <path>`      | Path to a private key to use. See [HTTPS](/features/development/#https).              |
-| `--no-hmr`          | Disables [hot reloading](/features/development/#hot-reloading).                       |
-| `--hmr-port <port>` | The port for the HMR server (defaults to the dev server's port). See [Hot reloading](/features/development/#hot-reloading).     
-| `--hmr-host <host>` | The host for the HMR server (defaults to the dev server's host). See [Hot reloading](/features/development/#hot-reloading).                       |
-| `--no-autoinstall`  | Disables [auto install](/features/development/#auto-install).                         |
-| `--watch-for-stdin` | Stop Parcel once stdin is closed.                                                     |
+| Format              | Description                                                                                                                                |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `-p, --port <port>` | The port for the dev server and HMR (the default port is `process.env.PORT` or 1234). See [Dev server](/features/development/#dev-server). |
+| `--host <host>`     | Sets the host to listen on, defaults to listening on all interfaces                                                                        |
+| `--https`           | Runs the dev server and HMR server over [HTTPS](/features/development/#https).                                                             |
+| `--cert <path>`     | Path to a certificate to use. See [HTTPS](/features/development/#https).                                                                   |
+| `--key <path>`      | Path to a private key to use. See [HTTPS](/features/development/#https).                                                                   |
+| `--no-hmr`          | Disables [hot reloading](/features/development/#hot-reloading).                                                                            |
+| `--hmr-port <port>` | The port for the HMR server (defaults to the dev server's port). See [Hot reloading](/features/development/#hot-reloading).                |
+| `--hmr-host <host>` | The host for the HMR server (defaults to the dev server's host). See [Hot reloading](/features/development/#hot-reloading).                |
+| `--no-autoinstall`  | Disables [auto install](/features/development/#auto-install).                                                                              |
+| `--watch-for-stdin` | Stop Parcel once stdin is closed.                                                                                                          |
 
 ### Parameters specific to `serve`
 
-| Format             | Description                                                                    |
-| ------------------ | ------------------------------------------------------------------------------ |
+| Format             | Description                                                                                                                          |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
 | `--open [browser]` | Automatically opens the entry in your browser. Defaults to the default browser. See [Dev server](/features/development/#dev-server). |
-| `--lazy`           | Only builds bundles requested by the dev server. See [Lazy mode](/features/development/#lazy-mode). |
+| `--lazy`           | Only builds bundles requested by the dev server. See [Lazy mode](/features/development/#lazy-mode).                                  |
 
 ### Parameters specific to `build`
 
-| Format                      | Description                                                                                                                                                  |
-| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `--no-optimize`             | Disables optimizations such as minification. <br> Overrides the [`optimize`](/features/targets/#optimize) option of package.json `targets`. See [Production](/features/production/).                 |
-| `--no-scope-hoist`          | Disables scope hoisting. <br> Overrides the [`scopeHoist`](/features/targets/#scopehoist) option of package.json `targets`. See [Scope hoisting](/features/scope-hoisting/).      
-| `--no-content-hash`         | Disables content hashing of output file names. <br> Bundle names may still include hashes, but they will not change on each build. See [Content hashing](/features/production/#content-hashing). |                                                  |
-| `--detailed-report [depth]` | Displays the largest 10 (number configurable with `depth`) assets per bundle in the CLI report. See [Detailed report](/features/production/#detailed-report).                                                              |
+| Format                      | Description                                                                                                                                                                                      |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --- |
+| `--no-optimize`             | Disables optimizations such as minification. <br> Overrides the [`optimize`](/features/targets/#optimize) option of package.json `targets`. See [Production](/features/production/).             |
+| `--no-scope-hoist`          | Disables scope hoisting. <br> Overrides the [`scopeHoist`](/features/targets/#scopehoist) option of package.json `targets`. See [Scope hoisting](/features/scope-hoisting/).                     |
+| `--no-content-hash`         | Disables content hashing of output file names. <br> Bundle names may still include hashes, but they will not change on each build. See [Content hashing](/features/production/#content-hashing). |     |
+| `--detailed-report [depth]` | Displays the largest 10 (number configurable with `depth`) assets per bundle in the CLI report. See [Detailed report](/features/production/#detailed-report).                                    |

--- a/src/features/parcel-api.md
+++ b/src/features/parcel-api.md
@@ -4,7 +4,7 @@ title: Parcel API
 eleventyNavigation:
   key: features-parcel-api
   title: 📚 Parcel API
-  order: 11
+  order: 10
 ---
 
 The Parcel API can be used to programmatically run builds or watch a project for changes. It is the same API as is used by the Parcel CLI. Use the API when you need more flexibility, or need to integrate Parcel into another build system.

--- a/src/features/parcel-api.md
+++ b/src/features/parcel-api.md
@@ -4,7 +4,7 @@ title: Parcel API
 eleventyNavigation:
   key: features-parcel-api
   title: 📚 Parcel API
-  order: 10
+  order: 11
 ---
 
 The Parcel API can be used to programmatically run builds or watch a project for changes. It is the same API as is used by the Parcel CLI. Use the API when you need more flexibility, or need to integrate Parcel into another build system.
@@ -28,11 +28,11 @@ There are two required parameters:
 {% samplefile "build.mjs" %}
 
 ```javascript
-import {Parcel} from '@parcel/core';
+import { Parcel } from "@parcel/core";
 
 let bundler = new Parcel({
-  entries: 'a.js',
-  defaultConfig: '@parcel/config-default'
+  entries: "a.js",
+  defaultConfig: "@parcel/config-default",
 });
 ```
 
@@ -49,17 +49,17 @@ You can also use the `defaultTargetOptions` to set values for [Targets](/feature
 {% samplefile "build.mjs" %}
 
 ```javascript
-import {Parcel} from '@parcel/core';
+import { Parcel } from "@parcel/core";
 
 let bundler = new Parcel({
-  entries: 'a.js',
-  defaultConfig: '@parcel/config-default',
-  mode: 'production',
+  entries: "a.js",
+  defaultConfig: "@parcel/config-default",
+  mode: "production",
   defaultTargetOptions: {
     engines: {
-      browsers: ['last 1 Chrome version']
-    }
-  }
+      browsers: ["last 1 Chrome version"],
+    },
+  },
 });
 ```
 
@@ -72,12 +72,12 @@ When set to an array, the `targets` option can be used to specify which of the p
 {% samplefile "build.mjs" %}
 
 ```javascript
-import {Parcel} from '@parcel/core';
+import { Parcel } from "@parcel/core";
 
 let bundler = new Parcel({
-  entries: 'a.js',
-  defaultConfig: '@parcel/config-default',
-  targets: ['modern']
+  entries: "a.js",
+  defaultConfig: "@parcel/config-default",
+  targets: ["modern"],
 });
 ```
 
@@ -90,24 +90,24 @@ Alternatively, `targets` may be set to an object, which will override any target
 {% samplefile "build.mjs" %}
 
 ```javascript
-import {Parcel} from '@parcel/core';
+import { Parcel } from "@parcel/core";
 
 let bundler = new Parcel({
-  entries: 'a.js',
-  defaultConfig: '@parcel/config-default',
-  mode: 'production',
+  entries: "a.js",
+  defaultConfig: "@parcel/config-default",
+  mode: "production",
   targets: {
     modern: {
       engines: {
-        browsers: ['last 1 Chrome version']
-      }
+        browsers: ["last 1 Chrome version"],
+      },
     },
     legacy: {
       engines: {
-        browsers: ['IE 11']
-      }
-    }
-  }
+        browsers: ["IE 11"],
+      },
+    },
+  },
 });
 ```
 
@@ -122,15 +122,15 @@ Environment variables such as `NODE_ENV` may be set using the `env` option. This
 {% samplefile "build.mjs" %}
 
 ```javascript
-import {Parcel} from '@parcel/core';
+import { Parcel } from "@parcel/core";
 
 let bundler = new Parcel({
-  entries: 'a.js',
-  defaultConfig: '@parcel/config-default',
-  mode: 'production',
+  entries: "a.js",
+  defaultConfig: "@parcel/config-default",
+  mode: "production",
   env: {
-    NODE_ENV: 'production'
-  }
+    NODE_ENV: "production",
+  },
 });
 ```
 
@@ -145,18 +145,18 @@ By default, Parcel does not write any output to the CLI when you use the API. Th
 {% samplefile "build.mjs" %}
 
 ```javascript
-import {Parcel} from '@parcel/core';
-import {fileURLToPath} from 'url';
+import { Parcel } from "@parcel/core";
+import { fileURLToPath } from "url";
 
 let bundler = new Parcel({
-  entries: 'a.js',
-  defaultConfig: '@parcel/config-default',
+  entries: "a.js",
+  defaultConfig: "@parcel/config-default",
   additionalReporters: [
     {
-      packageName: '@parcel/reporter-cli',
-      resolveFrom: fileURLToPath(import.meta.url)
-    }
-  ]
+      packageName: "@parcel/reporter-cli",
+      resolveFrom: fileURLToPath(import.meta.url),
+    },
+  ],
 });
 ```
 
@@ -171,15 +171,15 @@ Once you’ve constructed a `Parcel` instance, you can use it to build a project
 {% samplefile "build.mjs" %}
 
 ```javascript
-import {Parcel} from '@parcel/core';
+import { Parcel } from "@parcel/core";
 
 let bundler = new Parcel({
-  entries: 'a.js',
-  defaultConfig: '@parcel/config-default'
+  entries: "a.js",
+  defaultConfig: "@parcel/config-default",
 });
 
 try {
-  let {bundleGraph, buildTime} = await bundler.run();
+  let { bundleGraph, buildTime } = await bundler.run();
   let bundles = bundleGraph.getBundles();
   console.log(`✨ Built ${bundles.length} bundles in ${buildTime}ms!`);
 } catch (err) {
@@ -200,11 +200,11 @@ To watch a project for changes and be notified of each rebuild, use the `watch` 
 {% samplefile "build.mjs" %}
 
 ```javascript
-import {Parcel} from '@parcel/core';
+import { Parcel } from "@parcel/core";
 
 let bundler = new Parcel({
-  entries: 'a.js',
-  defaultConfig: '@parcel/config-default'
+  entries: "a.js",
+  defaultConfig: "@parcel/config-default",
 });
 
 let subscription = await bundler.watch((err, event) => {
@@ -213,10 +213,10 @@ let subscription = await bundler.watch((err, event) => {
     throw err;
   }
 
-  if (event.type === 'buildSuccess') {
+  if (event.type === "buildSuccess") {
     let bundles = event.bundleGraph.getBundles();
     console.log(`✨ Built ${bundles.length} bundles in ${event.buildTime}ms!`);
-  } else if (event.type === 'buildFailure') {
+  } else if (event.type === "buildFailure") {
     console.log(event.diagnostics);
   }
 });
@@ -236,17 +236,17 @@ The development server is included in the default Parcel config. It can be enabl
 {% samplefile "build.mjs" %}
 
 ```javascript
-import {Parcel} from '@parcel/core';
+import { Parcel } from "@parcel/core";
 
 let bundler = new Parcel({
-  entries: 'a.js',
-  defaultConfig: '@parcel/config-default',
+  entries: "a.js",
+  defaultConfig: "@parcel/config-default",
   serveOptions: {
-    port: 3000
+    port: 3000,
   },
   hmrOptions: {
-    port: 3000
-  }
+    port: 3000,
+  },
 });
 
 await bundler.watch();
@@ -267,25 +267,25 @@ This example writes its output into an in-memory file system, and logs the conte
 {% samplefile "build.mjs" %}
 
 ```javascript
-import {Parcel, createWorkerFarm} from '@parcel/core';
-import {MemoryFS} from '@parcel/fs';
+import { Parcel, createWorkerFarm } from "@parcel/core";
+import { MemoryFS } from "@parcel/fs";
 
 let workerFarm = createWorkerFarm();
 let outputFS = new MemoryFS(workerFarm);
 
 let bundler = new Parcel({
-  entries: 'a.js',
-  defaultConfig: '@parcel/config-default',
+  entries: "a.js",
+  defaultConfig: "@parcel/config-default",
   workerFarm,
-  outputFS
+  outputFS,
 });
 
 try {
-  let {bundleGraph} = await bundler.run();
+  let { bundleGraph } = await bundler.run();
 
   for (let bundle of bundleGraph.getBundles()) {
     console.log(bundle.filePath);
-    console.log(await outputFS.readFile(bundle.filePath, 'utf8'));
+    console.log(await outputFS.readFile(bundle.filePath, "utf8"));
   }
 } finally {
   await workerFarm.end();

--- a/src/features/parcel-api.md
+++ b/src/features/parcel-api.md
@@ -28,11 +28,11 @@ There are two required parameters:
 {% samplefile "build.mjs" %}
 
 ```javascript
-import { Parcel } from "@parcel/core";
+import {Parcel} from '@parcel/core';
 
 let bundler = new Parcel({
-  entries: "a.js",
-  defaultConfig: "@parcel/config-default",
+  entries: 'a.js',
+  defaultConfig: '@parcel/config-default'
 });
 ```
 
@@ -49,17 +49,17 @@ You can also use the `defaultTargetOptions` to set values for [Targets](/feature
 {% samplefile "build.mjs" %}
 
 ```javascript
-import { Parcel } from "@parcel/core";
+import {Parcel} from '@parcel/core';
 
 let bundler = new Parcel({
-  entries: "a.js",
-  defaultConfig: "@parcel/config-default",
-  mode: "production",
+  entries: 'a.js',
+  defaultConfig: '@parcel/config-default',
+  mode: 'production',
   defaultTargetOptions: {
     engines: {
-      browsers: ["last 1 Chrome version"],
-    },
-  },
+      browsers: ['last 1 Chrome version']
+    }
+  }
 });
 ```
 
@@ -72,12 +72,12 @@ When set to an array, the `targets` option can be used to specify which of the p
 {% samplefile "build.mjs" %}
 
 ```javascript
-import { Parcel } from "@parcel/core";
+import {Parcel} from '@parcel/core';
 
 let bundler = new Parcel({
-  entries: "a.js",
-  defaultConfig: "@parcel/config-default",
-  targets: ["modern"],
+  entries: 'a.js',
+  defaultConfig: '@parcel/config-default',
+  targets: ['modern']
 });
 ```
 
@@ -90,24 +90,24 @@ Alternatively, `targets` may be set to an object, which will override any target
 {% samplefile "build.mjs" %}
 
 ```javascript
-import { Parcel } from "@parcel/core";
+import {Parcel} from '@parcel/core';
 
 let bundler = new Parcel({
-  entries: "a.js",
-  defaultConfig: "@parcel/config-default",
-  mode: "production",
+  entries: 'a.js',
+  defaultConfig: '@parcel/config-default',
+  mode: 'production',
   targets: {
     modern: {
       engines: {
-        browsers: ["last 1 Chrome version"],
-      },
+        browsers: ['last 1 Chrome version']
+      }
     },
     legacy: {
       engines: {
-        browsers: ["IE 11"],
-      },
-    },
-  },
+        browsers: ['IE 11']
+      }
+    }
+  }
 });
 ```
 
@@ -122,15 +122,15 @@ Environment variables such as `NODE_ENV` may be set using the `env` option. This
 {% samplefile "build.mjs" %}
 
 ```javascript
-import { Parcel } from "@parcel/core";
+import {Parcel} from '@parcel/core';
 
 let bundler = new Parcel({
-  entries: "a.js",
-  defaultConfig: "@parcel/config-default",
-  mode: "production",
+  entries: 'a.js',
+  defaultConfig: '@parcel/config-default',
+  mode: 'production',
   env: {
-    NODE_ENV: "production",
-  },
+    NODE_ENV: 'production'
+  }
 });
 ```
 
@@ -145,18 +145,18 @@ By default, Parcel does not write any output to the CLI when you use the API. Th
 {% samplefile "build.mjs" %}
 
 ```javascript
-import { Parcel } from "@parcel/core";
-import { fileURLToPath } from "url";
+import {Parcel} from '@parcel/core';
+import {fileURLToPath} from 'url';
 
 let bundler = new Parcel({
-  entries: "a.js",
-  defaultConfig: "@parcel/config-default",
+  entries: 'a.js',
+  defaultConfig: '@parcel/config-default',
   additionalReporters: [
     {
-      packageName: "@parcel/reporter-cli",
-      resolveFrom: fileURLToPath(import.meta.url),
-    },
-  ],
+      packageName: '@parcel/reporter-cli',
+      resolveFrom: fileURLToPath(import.meta.url)
+    }
+  ]
 });
 ```
 
@@ -171,15 +171,15 @@ Once you’ve constructed a `Parcel` instance, you can use it to build a project
 {% samplefile "build.mjs" %}
 
 ```javascript
-import { Parcel } from "@parcel/core";
+import {Parcel} from '@parcel/core';
 
 let bundler = new Parcel({
-  entries: "a.js",
-  defaultConfig: "@parcel/config-default",
+  entries: 'a.js',
+  defaultConfig: '@parcel/config-default'
 });
 
 try {
-  let { bundleGraph, buildTime } = await bundler.run();
+  let {bundleGraph, buildTime} = await bundler.run();
   let bundles = bundleGraph.getBundles();
   console.log(`✨ Built ${bundles.length} bundles in ${buildTime}ms!`);
 } catch (err) {
@@ -200,11 +200,11 @@ To watch a project for changes and be notified of each rebuild, use the `watch` 
 {% samplefile "build.mjs" %}
 
 ```javascript
-import { Parcel } from "@parcel/core";
+import {Parcel} from '@parcel/core';
 
 let bundler = new Parcel({
-  entries: "a.js",
-  defaultConfig: "@parcel/config-default",
+  entries: 'a.js',
+  defaultConfig: '@parcel/config-default'
 });
 
 let subscription = await bundler.watch((err, event) => {
@@ -213,10 +213,10 @@ let subscription = await bundler.watch((err, event) => {
     throw err;
   }
 
-  if (event.type === "buildSuccess") {
+  if (event.type === 'buildSuccess') {
     let bundles = event.bundleGraph.getBundles();
     console.log(`✨ Built ${bundles.length} bundles in ${event.buildTime}ms!`);
-  } else if (event.type === "buildFailure") {
+  } else if (event.type === 'buildFailure') {
     console.log(event.diagnostics);
   }
 });
@@ -236,17 +236,17 @@ The development server is included in the default Parcel config. It can be enabl
 {% samplefile "build.mjs" %}
 
 ```javascript
-import { Parcel } from "@parcel/core";
+import {Parcel} from '@parcel/core';
 
 let bundler = new Parcel({
-  entries: "a.js",
-  defaultConfig: "@parcel/config-default",
+  entries: 'a.js',
+  defaultConfig: '@parcel/config-default',
   serveOptions: {
-    port: 3000,
+    port: 3000
   },
   hmrOptions: {
-    port: 3000,
-  },
+    port: 3000
+  }
 });
 
 await bundler.watch();
@@ -267,25 +267,25 @@ This example writes its output into an in-memory file system, and logs the conte
 {% samplefile "build.mjs" %}
 
 ```javascript
-import { Parcel, createWorkerFarm } from "@parcel/core";
-import { MemoryFS } from "@parcel/fs";
+import {Parcel, createWorkerFarm} from '@parcel/core';
+import {MemoryFS} from '@parcel/fs';
 
 let workerFarm = createWorkerFarm();
 let outputFS = new MemoryFS(workerFarm);
 
 let bundler = new Parcel({
-  entries: "a.js",
-  defaultConfig: "@parcel/config-default",
+  entries: 'a.js',
+  defaultConfig: '@parcel/config-default',
   workerFarm,
-  outputFS,
+  outputFS
 });
 
 try {
-  let { bundleGraph } = await bundler.run();
+  let {bundleGraph} = await bundler.run();
 
   for (let bundle of bundleGraph.getBundles()) {
     console.log(bundle.filePath);
-    console.log(await outputFS.readFile(bundle.filePath, "utf8"));
+    console.log(await outputFS.readFile(bundle.filePath, 'utf8'));
   }
 } finally {
   await workerFarm.end();

--- a/src/features/plugins.md
+++ b/src/features/plugins.md
@@ -109,7 +109,7 @@ If you’d like to define a higher priority pipeline that extends a lower priori
 
 In the above example, when processing `icons/home.svg`, we first run `@company/parcel-transformer-svg-icons` and then `@parcel/transformer-svg`.
 
-This also applies to configs that have been extended. If a `"..."` is used and there are no lower priority pipelines defined in the current config, Parcel falls back to pipelines defined in the extended configs.
+This also applies to configs that have been extended. If a  `"..."` is used and there are no lower priority pipelines defined in the current config, Parcel falls back to pipelines defined in the extended configs.
 
 Since `@parcel/transformer-svg` is included in the default config, the above example could be rewritten like this:
 
@@ -164,7 +164,7 @@ You can also define your own named pipelines. For example, you could define an `
 {% samplefile "src/example.js" %}
 
 ```javascript
-import buffer from "arraybuffer:./file.png";
+import buffer from 'arraybuffer:./file.png';
 ```
 
 {% endsamplefile %}

--- a/src/features/plugins.md
+++ b/src/features/plugins.md
@@ -4,7 +4,7 @@ title: Plugins
 eleventyNavigation:
   key: features-plugins
   title: 🔌 Plugins
-  order: 11
+  order: 12
 ---
 
 Parcel works out of the box for many projects with zero configuration. But if you want more control, or need to extend or override Parcel’s defaults, you can do so by creating a `.parcelrc` file in your project.
@@ -109,7 +109,7 @@ If you’d like to define a higher priority pipeline that extends a lower priori
 
 In the above example, when processing `icons/home.svg`, we first run `@company/parcel-transformer-svg-icons` and then `@parcel/transformer-svg`.
 
-This also applies to configs that have been extended. If a  `"..."` is used and there are no lower priority pipelines defined in the current config, Parcel falls back to pipelines defined in the extended configs.
+This also applies to configs that have been extended. If a `"..."` is used and there are no lower priority pipelines defined in the current config, Parcel falls back to pipelines defined in the extended configs.
 
 Since `@parcel/transformer-svg` is included in the default config, the above example could be rewritten like this:
 
@@ -164,7 +164,7 @@ You can also define your own named pipelines. For example, you could define an `
 {% samplefile "src/example.js" %}
 
 ```javascript
-import buffer from 'arraybuffer:./file.png';
+import buffer from "arraybuffer:./file.png";
 ```
 
 {% endsamplefile %}
@@ -375,7 +375,7 @@ If `"..."` is omitted, your namer must be able to handle naming all bundles or t
   "compressors": {
     "*.{js,html,css}": [
       "...",
-      "@parcel/compressor-gzip", 
+      "@parcel/compressor-gzip",
       "@parcel/compressor-brotli"
     ]
   }
@@ -486,4 +486,3 @@ In your root package.json, you can define a dependency on the `parcel-transforme
 {% endsample %}
 
 Then, in your `.parcelrc` you can reference `parcel-transformer-foo` as you would a published package. Whenever you update the code for your plugin, Parcel will rebuild your project.
-

--- a/src/features/profiling.md
+++ b/src/features/profiling.md
@@ -4,7 +4,7 @@ title: Profiling and tracing
 eleventyNavigation:
   key: features-profiling
   title: 📈 Profiling and tracing
-  order: 10
+  order: 11
 ---
 
 ## Tracing

--- a/src/features/profiling.md
+++ b/src/features/profiling.md
@@ -11,7 +11,7 @@ eleventyNavigation:
 
 CPU profiling or sampling profiling generates a profile which tracks execution of JavaScript during the build, and can be used to identify parts of the codebase and where time was spent in it during the build. Application profiling is a higher level profile, that tracks specific phases of Parcel's execution, and which plugins were called into, and how long is spent in each.
 
-A Parcel application profile can help you to optimize your build by answering questions such as, "Which plugin is taking the most time during my build?" or "Which file in my project takes the longest to transform?". These questions are not as easy to answer with the data provided by a CPU sampling profile, but can be answered with a Parcel applicaiton profile.
+A Parcel application profile can help you to optimize your build by answering questions such as, "Which plugin is taking the most time during my build?" or "Which file in my project takes the longest to transform?". These questions are not as easy to answer with the data provided by a CPU sampling profile, but can be answered with a Parcel application profile.
 
 The overhead of running an application profile is relatively minimal, but is non-zero - it's certainly less expensive than running a sampling profile during the build. In particular, the JSON file produced can be quite large depending on the numbers of plugins you are using and the size of your build. Consider these factors when deciding when to enable application profiling.
 
@@ -23,16 +23,15 @@ To generate an application profile with the CLI, start Parcel with the `--profil
 
 #### API
 
-To generate an application profile when using the API, you must pass `shouldProfileApplication: true` with the Parcel options in order to enable the applicaiton profiling events. In addition, you will need to add the application profile reporter via `additionalReporters` to have Parcel create the profile JSON file. For example:
+To generate an application profile when using the API, you must pass `shouldProfileApplication: true` with the Parcel options in order to enable the application profiling events. In addition, you will need to add the application profile reporter via `additionalReporters` to have Parcel create the profile JSON file. For example:
 
 ```js
 {
     // options
     additionalReporters: [{
-        packageName: '@parcel/reporter-application-profiler',
-        resolveFrom: __dirname,
-      },
-    ],
+      packageName: '@parcel/reporter-application-profiler',
+      resolveFrom: __dirname,
+    }],
 }
 ```
 
@@ -50,7 +49,7 @@ The Parcel application profile consists only of type `X` Complete Events. The ra
 
 While you can load a Parcel application profile into Chrome Dev Tools, the analysis options for this kind of profile in that tool is fairly limited. This is because the data is not typical data that Dev Tools is designed for. The application profile events, for example, contain metadata that can be useful for deeper analysis and this metadata is not accessible through Dev Tools. In addition, a medium to large sized build may produce a volume of data that is not feasible to load into Chrome Dev Tools due to it's size.
 
-The recommended tool for analysing Parcel application profiles is [Perfetto](https://ui.perfetto.dev/), which is also built by Google, but specifically designed for dealing with large traces, and non-Browser traces. In particlar, the most useful part of Perfetto for analysing these traces is that it loads the data into an [SQLite](https://www.sqlite.org/index.html) database that can be queried via the UI - this allows us to answer the kinds of questions that were mentioned earlier.
+The recommended tool for analysing Parcel application profiles is [Perfetto](https://ui.perfetto.dev/), which is also built by Google, but specifically designed for dealing with large traces, and non-browser traces. In particular, the most useful part of Perfetto for analysing these traces is that it loads the data into an [SQLite](https://www.sqlite.org/index.html) database that can be queried via the UI - this allows us to answer the kinds of questions that were mentioned earlier.
 
 #### Example queries
 
@@ -90,7 +89,7 @@ order by dur_ms desc
 
 ##### Which Babel plugins are ones are taking the most time in my build?
 
-This can be useful to identify which Babel plugins that are still needed in your build, and exectued by `@parcel/transform-babel`, take the most time and so can be prioritised to be removed or replaced with Parcel transforms.
+This can be useful to identify which Babel plugins that are still needed in your build, and executed by `@parcel/transform-babel`, take the most time and so can be prioritised to be removed or replaced with Parcel transforms.
 
 ```sql
 select

--- a/src/features/profiling.md
+++ b/src/features/profiling.md
@@ -9,7 +9,7 @@ eleventyNavigation:
 
 ## Tracing
 
-CPU profiling or sampling profiling generates a profile which tracks execution of JavaScript during the build, and can be used to identify parts of the codebase and where time was spent in it during the build. Tracing is a higher level profile, that tracks specific phases of Parcel's execution, and which plugins were called into, and how long is spent in each.
+CPU profiling or sampling profiling generates a profile which tracks execution of JavaScript during the build, and can be used to identify parts of the codebase and where time was spent in it during the build. Tracing is a higher level profile, that tracks specific phases of Parcel's execution, which plugins were called into, and how long is spent in each.
 
 A Parcel trace can help you to optimize your build by answering questions such as, "Which plugin is taking the most time during my build?" or "Which file in my project takes the longest to transform?". These questions are not as easy to answer with the data provided by a CPU sampling profile, but can be answered with a Parcel trace.
 
@@ -19,20 +19,23 @@ The overhead of running a trace is relatively minimal, but is non-zero - it's ce
 
 #### CLI
 
-To generate a trace with the CLI, start Parcel with the `--trace` CLI argument. Parcel will generate an [trace JSON](#format) file in the root of your project. Parcel will log the filename it is writing the trace to when the build starts.
+To generate a trace with the CLI, start Parcel with the `--trace` CLI argument. Parcel will generate a [trace JSON](#format) file in the root of your project. Parcel will log the filename it is writing the trace to when the build starts.
 
 #### API
 
 To generate a trace when using the API, you must pass `shouldTrace: true` with the Parcel options in order to enable the tracing events. In addition, you will need to add the tracer reporter via `additionalReporters` to have Parcel create the trace JSON file. For example:
 
 ```js
-{
-    // options
-    additionalReporters: [{
-      packageName: '@parcel/reporter-tracer',
-      resolveFrom: __dirname,
-    }],
-}
+import {Parcel} from '@parcel/core';
+
+let bundler = new Parcel({
+  // ...
+  shouldTrace: true,
+  additionalReporters: [{
+    packageName: '@parcel/reporter-tracer',
+    resolveFrom: __dirname,
+  }],
+});
 ```
 
 ### Format

--- a/src/features/profiling.md
+++ b/src/features/profiling.md
@@ -15,9 +15,28 @@ A Parcel application profile can help you to optimize your build by answering qu
 
 The overhead of running an application profile is relatively minimal, but is non-zero - it's certainly less expensive than running a sampling profile during the build. In particular, the JSON file produced can be quite large depending on the numbers of plugins you are using and the size of your build. Consider these factors when deciding when to enable application profiling.
 
-### Format
+### Usage
 
-When executed with the `--profile-application` CLI argument, or when `shouldProfileApplication` is set to `true` in the options passed to Parcel when it is called via the API, then Parcel will generate an application profile JSON file in the root of your project. Parcel will log the filename it is writing the profile to when the build starts.
+#### CLI
+
+To generate an application profile with the CLI, start Parcel with the `--profile-application` CLI argument. Parcel will generate an [application profile JSON](#format) file in the root of your project. Parcel will log the filename it is writing the profile to when the build starts.
+
+#### API
+
+To generate an application profile when using the API, you must pass `shouldProfileApplication: true` with the Parcel options in order to enable the applicaiton profiling events. In addition, you will need to add the application profile reporter via `additionalReporters` to have Parcel create the profile JSON file. For example:
+
+```js
+{
+    // options
+    additionalReporters: [{
+        packageName: '@parcel/reporter-application-profiler',
+        resolveFrom: __dirname,
+      },
+    ],
+}
+```
+
+### Format
 
 This file uses the [Chrome Tracing Format](https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview), similar to CPU profiles, but analysing it is a little bit different.
 

--- a/src/features/profiling.md
+++ b/src/features/profiling.md
@@ -1,35 +1,35 @@
 ---
 layout: layout.njk
-title: Profiling
+title: Profiling and tracing
 eleventyNavigation:
   key: features-profiling
-  title: 📈 Profiling
+  title: 📈 Profiling and tracing
   order: 10
 ---
 
-## Application profiling
+## Tracing
 
-CPU profiling or sampling profiling generates a profile which tracks execution of JavaScript during the build, and can be used to identify parts of the codebase and where time was spent in it during the build. Application profiling is a higher level profile, that tracks specific phases of Parcel's execution, and which plugins were called into, and how long is spent in each.
+CPU profiling or sampling profiling generates a profile which tracks execution of JavaScript during the build, and can be used to identify parts of the codebase and where time was spent in it during the build. Tracing is a higher level profile, that tracks specific phases of Parcel's execution, and which plugins were called into, and how long is spent in each.
 
-A Parcel application profile can help you to optimize your build by answering questions such as, "Which plugin is taking the most time during my build?" or "Which file in my project takes the longest to transform?". These questions are not as easy to answer with the data provided by a CPU sampling profile, but can be answered with a Parcel application profile.
+A Parcel trace can help you to optimize your build by answering questions such as, "Which plugin is taking the most time during my build?" or "Which file in my project takes the longest to transform?". These questions are not as easy to answer with the data provided by a CPU sampling profile, but can be answered with a Parcel trace.
 
-The overhead of running an application profile is relatively minimal, but is non-zero - it's certainly less expensive than running a sampling profile during the build. In particular, the JSON file produced can be quite large depending on the numbers of plugins you are using and the size of your build. Consider these factors when deciding when to enable application profiling.
+The overhead of running a trace is relatively minimal, but is non-zero - it's certainly less expensive than running a sampling profile during the build. In particular, the JSON file produced can be quite large depending on the numbers of plugins you are using and the size of your build. Consider these factors when deciding when to enable tracing.
 
 ### Usage
 
 #### CLI
 
-To generate an application profile with the CLI, start Parcel with the `--profile-application` CLI argument. Parcel will generate an [application profile JSON](#format) file in the root of your project. Parcel will log the filename it is writing the profile to when the build starts.
+To generate a trace with the CLI, start Parcel with the `--trace` CLI argument. Parcel will generate an [trace JSON](#format) file in the root of your project. Parcel will log the filename it is writing the trace to when the build starts.
 
 #### API
 
-To generate an application profile when using the API, you must pass `shouldProfileApplication: true` with the Parcel options in order to enable the application profiling events. In addition, you will need to add the application profile reporter via `additionalReporters` to have Parcel create the profile JSON file. For example:
+To generate a trace when using the API, you must pass `shouldTrace: true` with the Parcel options in order to enable the tracing events. In addition, you will need to add the tracer reporter via `additionalReporters` to have Parcel create the trace JSON file. For example:
 
 ```js
 {
     // options
     additionalReporters: [{
-      packageName: '@parcel/reporter-application-profiler',
+      packageName: '@parcel/reporter-tracer',
       resolveFrom: __dirname,
     }],
 }
@@ -37,23 +37,23 @@ To generate an application profile when using the API, you must pass `shouldProf
 
 ### Format
 
-This file uses the [Chrome Tracing Format](https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview), similar to CPU profiles, but analysing it is a little bit different.
+The tracing JSON file uses the [Chrome Tracing Format](https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview), similar to CPU profiles, but analysing it is a little bit different.
 
-The Parcel application profile consists only of type `X` Complete Events. The raw events look like this:
+The Parcel trace consists only of type `X` Complete Events. The raw events look like this:
 
 ```json
 {"ts":6020131,"pid":11738,"tid":4,"ph":"X","name":"@parcel/transformer-js","cat":"transform","args":{"name":"src/index.html"},"dur":11642},
 ```
 
-### Analysing application profiles
+### Analysing traces
 
-While you can load a Parcel application profile into Chrome Dev Tools, the analysis options for this kind of profile in that tool is fairly limited. This is because the data is not typical data that Dev Tools is designed for. The application profile events, for example, contain metadata that can be useful for deeper analysis and this metadata is not accessible through Dev Tools. In addition, a medium to large sized build may produce a volume of data that is not feasible to load into Chrome Dev Tools due to it's size.
+While you can load a Parcel trace into Chrome Dev Tools, the analysis options for this kind of profile in that tool is fairly limited. This is because the data is not typical data that Dev Tools is designed for. The trace events, for example, contain metadata that can be useful for deeper analysis and this metadata is not accessible through Dev Tools. In addition, a medium to large sized build may produce a volume of data that is not feasible to load into Chrome Dev Tools due to it's size.
 
-The recommended tool for analysing Parcel application profiles is [Perfetto](https://ui.perfetto.dev/), which is also built by Google, but specifically designed for dealing with large traces, and non-browser traces. In particular, the most useful part of Perfetto for analysing these traces is that it loads the data into an [SQLite](https://www.sqlite.org/index.html) database that can be queried via the UI - this allows us to answer the kinds of questions that were mentioned earlier.
+The recommended tool for analysing Parcel traces is [Perfetto](https://ui.perfetto.dev/), which is also built by Google, but specifically designed for dealing with large traces, and non-browser traces. In particular, the most useful part of Perfetto for analysing these traces is that it loads the data into an [SQLite](https://www.sqlite.org/index.html) database that can be queried via the UI - this allows us to answer the kinds of questions that were mentioned earlier.
 
 #### Example queries
 
-Here are some example queries you can enter into the "Query (SQL)" function in Perfetto to generate some useful statistics about your Parcel builds. Keep in mind that the durations in these results are total sampled time - given Parcel's multi-threaded implementation, some of these total times will exceed the wall time of your Parcel build.
+Here are some example queries you can enter into the "Query (SQL)" function in Perfetto to generate some useful statistics about your Parcel builds. Keep in mind that the durations in these results are total sampled time - given Parcel's multi-threaded implementation, some of these total times may exceed the wall time of your Parcel build.
 
 ##### What is the breakdown of my build by phase?
 

--- a/src/features/profiling.md
+++ b/src/features/profiling.md
@@ -1,0 +1,88 @@
+---
+layout: layout.njk
+title: Profiling
+eleventyNavigation:
+  key: features-profiling
+  title: 📈 Profiling
+  order: 10
+---
+
+## Application profiling
+
+CPU profiling or sampling profiling generates a profile which tracks execution of JavaScript during the build, and can be used to identify parts of the codebase and where time was spent in it during the build. Application profiling is a higher level profile, that tracks specific phases of Parcel's execution, and which plugins were called into, and how long is spent in each.
+
+A Parcel application profile can help you to optimize your build by answering questions such as, "Which plugin is taking the most time during my build?" or "Which file in my project takes the longest to transform?". These questions are not as easy to answer with the data provided by a CPU sampling profile, but can be answered with a Parcel applicaiton profile.
+
+The overhead of running an application profile is relatively minimal, but is non-zero - it's certainly less expensive than running a sampling profile during the build. In particular, the JSON file produced can be quite large depending on the numbers of plugins you are using and the size of your build. Consider these factors when deciding when to enable application profiling.
+
+### Format
+
+When executed with the `--profile-application` CLI argument, or when `shouldProfileApplication` is set to `true` in the options passed to Parcel when it is called via the API, then Parcel will generate an application profile JSON file in the root of your project. Parcel will log the filename it is writing the profile to when the build starts.
+
+This file uses the [Chrome Tracing Format](https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview), similar to CPU profiles, but analysing it is a little bit different.
+
+The Parcel application profile consists only of type `X` Complete Events. The raw events look like this:
+
+```json
+{"ts":6020131,"pid":11738,"tid":4,"ph":"X","name":"@parcel/transformer-js","cat":"transform","args":{"name":"src/index.html"},"dur":11642},
+```
+
+### Analysing application profiles
+
+While you can load a Parcel application profile into Chrome Dev Tools, the analysis options for this kind of profile in that tool is fairly limited. This is because the data is not typical data that Dev Tools is designed for. The application profile events, for example, contain metadata that can be useful for deeper analysis and this metadata is not accessible through Dev Tools. In addition, a medium to large sized build may produce a volume of data that is not feasible to load into Chrome Dev Tools due to it's size.
+
+The recommended tool for analysing Parcel application profiles is [Perfetto](https://ui.perfetto.dev/), which is also built by Google, but specifically designed for dealing with large traces, and non-Browser traces. In particlar, the most useful part of Perfetto for analysing these traces is that it loads the data into an [SQLite](https://www.sqlite.org/index.html) database that can be queried via the UI - this allows us to answer the kinds of questions that were mentioned earlier.
+
+#### Example queries
+
+Here are some example queries you can enter into the "Query (SQL)" function in Perfetto to generate some useful statistics about your Parcel builds. Keep in mind that the durations in these results are total sampled time - given Parcel's multi-threaded implementation, some of these total times will exceed the wall time of your Parcel build.
+
+##### What is the breakdown of my build by phase?
+
+This is a high level query that provides a breakdown by the main phases of your build - building, bundling, packaging - and can help to identify at a high level if any particular phase stands out as taking longer than expected.
+
+```sql
+select
+  name, SUM(CAST(dur AS double)/1000/1000) as dur_ms
+from
+  slice s
+where
+  s.category = "Core"
+group by name
+order by dur_ms desc
+```
+
+##### What are the plugins in my build that take the most time?
+
+This can be useful to identify at a high level which plugins Parcel spends the most time in. While some of these are going to be core plugins, in a build where you are using custom plugins, or other third-party plugins, this can be a useful query to identify if any of these plugins stand out as taking an unexpected amount of time - which can be useful for identifying optimisation opportunities.
+
+```sql
+select
+  s.category, name, SUM(CAST(dur AS double)/1000/1000) as dur_ms
+from
+  slice s
+left join
+  args using(arg_set_id)
+where
+  args.flat_key = "args.name"
+group by s.category, name
+order by dur_ms desc
+```
+
+##### Which Babel plugins are ones are taking the most time in my build?
+
+This can be useful to identify which Babel plugins that are still needed in your build, and exectued by `@parcel/transform-babel`, take the most time and so can be prioritised to be removed or replaced with Parcel transforms.
+
+```sql
+select
+  name, SUM(CAST(dur AS double)/1000/1000) as dur_ms
+from
+  slice s
+left join
+  args using(arg_set_id)
+where
+  args.flat_key = "args.name" AND
+  s.category LIKE "transform:@parcel/transformer-babel%"
+group by name
+order by dur_ms desc
+```


### PR DESCRIPTION
This relates to https://github.com/parcel-bundler/parcel/pull/8695 - initial cut at a documentation page for the application profiling feature. This shouldn't be merged / deployed until Application Profiling is.