### PR TITLE
Glob: Improve example snippet

### DIFF
--- a/src/features/dependency-resolution.md
+++ b/src/features/dependency-resolution.md
@@ -176,7 +176,7 @@ Parcel supports importing multiple files at once via globs, however, since glob 
 ```json
 {
   "extends": "@parcel/config-default",
-  "resolvers": ["@parcel/resolver-glob", "..."]
+  "resolvers": ["@parcel/resolver-glob", "@parcel/resolver-default", "..."]
 }
 ```
 


### PR DESCRIPTION
Without "@parcel/resolver-default" other resolves such as src/index.html will not work.