### PR TITLE
Update getting_started.md

### DIFF
--- a/src/i18n/ru/docs/getting_started.md
+++ b/src/i18n/ru/docs/getting_started.md
@@ -13,7 +13,7 @@ yarn global add parcel-bundler
 npm:
 
 ```bash
-npm install -g parcel-bundler
+npm install -g parcel
 ```
 
 Создайте файл package.json в папке вашего проекта, используя:


### PR DESCRIPTION
Do not use npm install -g parcel-bundler because installation is not possible, only npm install -g parcel works, I struggled for several hours until I read an article where they wrote that it no longer works