### PR TITLE
Update vue.md

### DIFF
--- a/src/languages/vue.md
+++ b/src/languages/vue.md
@@ -208,7 +208,7 @@ export default function (component, blockContent, blockAttrs) {
       child: Child,
     },
     data() {
-      let docs = { standard: Child.__docs, brief: Child.__docsBrief };
+      let docs = { standard: Child.__docs, brief: Child.__briefDocs };
       return { docs };
     },
   };


### PR DESCRIPTION
From https://github.com/parcel-bundler/website/pull/1087

> The ``App.vue`` contains an attempt to access a prop ``__docsBrief``, which was confused with the correct one ``__briefDocs`` in the ``src/docs-preprocessor.js``
