### PR TITLE
fix: stretched out sidebar icons

### DIFF
--- a/src/assets/styles/doc-styles.scss
+++ b/src/assets/styles/doc-styles.scss
@@ -439,6 +439,7 @@ body {
     vertical-align: middle;
     display: inline-block;
     margin-right: 0.25em;
+    object-fit: contain;
   }
 }
 


### PR DESCRIPTION
Non-square icons on the sidebar are stretched out, adding `object-fit: contain` allows to keep their original aspect ratio.

| before | after |
|---|---|
|![23-09-07_14-09-16_ErW65](https://github.com/parcel-bundler/website/assets/7945905/96b930d4-03ea-4a4c-80ea-0ae5216895ad)|![23-09-07_14-09-07_firefox_RntXo](https://github.com/parcel-bundler/website/assets/7945905/1e0ba2f5-a8a9-4488-b46a-14701d04694e)|
