### PR TITLE
Transform noise in calc_frag_color to vec3

### DIFF
--- a/src/languages/glsl.md
+++ b/src/languages/glsl.md
@@ -59,7 +59,7 @@ void main() {
 #pragma glslify: noise = require('glsl-noise/simplex/3d')
 
 vec4 calc_frag_color(vec3 pos) {
-  return vec4(noise(pos * 25.0), 1);
+  return vec4(vec3(noise(pos * 25.0)), 1.0);
 }
 
 // export a function


### PR DESCRIPTION
noise function in glsl-noise/simplex/3d returns float, so it has to be transformed to vec3.