### PR TITLE
Add Manual Shared Bundle Blurb to Code splitting doc

### DIFF
--- a/src/features/code-splitting.md
+++ b/src/features/code-splitting.md
@@ -233,18 +233,26 @@ For this reason, dynamic import is merely a *hint* that a dependency is not need
 
 If a dynamically imported module has a dependency that is already available in all of its possible ancestries, it will be deduplicated. For example, if a page imports a library which is also used by a dynamically imported module, the library will only be included in the parent since it will already be on the page at runtime.
 
-## Manual Shared Bundles (EXPERIMENTAL)
+## Manual shared bundles
 
-Parcel automatically splits out commonly used modules into "shared bundles" and creates bundles in the scenarios listed above. However, in certain cases, you may want to specify exactly what goes into a bundle and who can request that bundle.
+{% warning %}
+
+**Note**: Manual shared bundles are currently experimental and subject to change.
+
+{% endwarning %}
+
+By default, Parcel automatically splits commonly used modules into "shared bundles" and creates bundles in the scenarios listed above. However, in certain cases, you may want to specify exactly what goes into a bundle and who can request that bundle.
 
 These scenarios include but are not limited to...
 
 - Porting over your config from another build tool or bundler to Parcel
 - Reducing your HTTP requests without duplicating assets, in favor of over-fetching
-  - We've found over-fetching and loading fewer bundles overall can greatly benefit measurements like TTI, especially for very large projects
+  - Over-fetching and loading fewer bundles overall can benefit measurements like [time-to-interactive](https://web.dev/articles/tti), especially for very large projects.
 - Creating an optimized shared bundle for a specific route or set of modules
 
-As of this writing, MSBs, or Manual Shared Bundles can be specified via `package.json` using globs which Parcel will match on.
+Manual Shared Bundles can be specified in your project root `package.json`. The `assets` property must be set to a list of globs. Any asset file paths matching these globs will be included in the manual shared bundle.
+
+This example creates a vendor bundle which includes all JS assets in the graph starting from `manual.js`, split into 3 parallel HTTP requests.
 
 {% sample %}
 {% samplefile "package.json" %}
@@ -257,7 +265,6 @@ As of this writing, MSBs, or Manual Shared Bundles can be specified via `package
         "name": "vendor",
         "root": "manual.js",
         "assets": ["**/*"],
-        "loadedBy": ["async1.js", "async2.js"],
         "types": ["js"],
         "split": 3
       },
@@ -269,22 +276,21 @@ As of this writing, MSBs, or Manual Shared Bundles can be specified via `package
 {% endsamplefile %}
 {% endsample %}
 
-`manualSharedBundles` takes an array of objects that require an `assets` field as an array of globs.
-
-The optional parameters are as follows:
+The full list of options are as follows:
 
 - **name** (optional) - Sets field `manualSharedBundle` on bundle to \<name\>, this can be read in a custom reporter or namer for development purposes
 - **root** (optional) - Narrows the scope of the glob to the file specified. In the example above, the glob, `**/*` will match all imports within `manual.js`
 - **assets** (required) - glob for Parcel to match on. Files that match the glob will be placed into a singular bundle, and deduplicated across the project unless otherwise specified. If no `root` is specified, Parcel attempts to match the glob **globally**.
-- **types** (optional) - Limits globs to only match on a certain type. This field must be set if your `root` file contains multiple types or if the glob can match different types, as a bundle can only contain assets of the same type.
-  - A **root** file can contain imports of multiple types, just make sure to add an object in the `manualSharedBundle` array per type.
+- **types** (optional) - Limits globs to only match on a certain type. This field must be set if your `root` file imports multiple types (e.g. JS and CSS) or if the `assets` glob can match different types. A bundle can only contain assets of the same type.
+  - A **root** file can contain imports of multiple types. Make sure to add an object in the `manualSharedBundle` array per type.
 - **split** (optional) - splits the manual bundle into x bundles. 
-  - We've found that, for very large bundles, splitting them can improve measurements like CHR (cache hit ratio), as a smaller bundle is invalidated for a given change. 
-- **loadedBy** (optional) - Narrows the scope of what bundles can reference your MSB (Manual Shared Bundle).
-  - This is useful in the case where your MSB is used by asynchronous modules. Specifying the `loadedBy` field with those asynchronous modules ensures that the MSB's load and execution time will in fact be deferred. Parcel will instead duplicate the asset(s) required by any bundles not included in `loadedBy`.
+  - For very large bundles, splitting into multiple parallel HTTP requests can improve measurements like CHR (cache hit ratio), as a smaller bundle is invalidated for a given change. 
 
 
+{% warning %}
 
-#### BE CAREFUL 
+**Be careful!**
 
-This feature will overwrite any automatic code splitting parcel does, and can cause unintended load-order issues as it maps on your **entire** code base, **including** `/node_modules`. Be mindful of the globs you use, only specify 1 bundle per file type, and we recommend you specify a **root** file. 
+Configuring manual shared bundles overrides all automatic code splitting normally done by Parcel, and can cause unintended load-order issues as it maps on your **entire** code base, **including** `node_modules`. Be mindful of the globs you use, only specify 1 bundle per file type, and we recommend you specify a **root** file. 
+
+{% endwarning %}

--- a/src/features/code-splitting.md
+++ b/src/features/code-splitting.md
@@ -233,7 +233,7 @@ For this reason, dynamic import is merely a *hint* that a dependency is not need
 
 If a dynamically imported module has a dependency that is already available in all of its possible ancestries, it will be deduplicated. For example, if a page imports a library which is also used by a dynamically imported module, the library will only be included in the parent since it will already be on the page at runtime.
 
-## Manual Shared Bundles (UNSTABLE)
+## Manual Shared Bundles (EXPERIMENTAL)
 
 Parcel automatically splits out commonly used modules into "shared bundles" and creates bundles in the scenarios listed above. However, in certain cases, you may want to specify exactly what goes into a bundle and who can request that bundle.
 
@@ -252,7 +252,7 @@ As of this writing, MSBs, or Manual Shared Bundles can be specified via `package
 ```json5
 {
   "@parcel/bundler-default": {
-   "unstable_manualSharedBundles": [
+   "manualSharedBundles": [
       {
         "name": "vendor",
         "root": "manual.js",
@@ -269,7 +269,7 @@ As of this writing, MSBs, or Manual Shared Bundles can be specified via `package
 {% endsamplefile %}
 {% endsample %}
 
-`unstable_manualSharedBundles` takes an array of objects, that require an `assets` field as an array of globs.
+`manualSharedBundles` takes an array of objects that require an `assets` field as an array of globs.
 
 The optional parameters are as follows:
 
@@ -277,8 +277,14 @@ The optional parameters are as follows:
 - **root** (optional) - Narrows the scope of the glob to the file specified. In the example above, the glob, `**/*` will match all imports within `manual.js`
 - **assets** (required) - glob for Parcel to match on. Files that match the glob will be placed into a singular bundle, and deduplicated across the project unless otherwise specified. If no `root` is specified, Parcel attempts to match the glob **globally**.
 - **types** (optional) - Limits globs to only match on a certain type. This field must be set if your `root` file contains multiple types or if the glob can match different types, as a bundle can only contain assets of the same type.
-  - A **root** file can contain imports of multiple types, just make sure to add an object in the `unstable_manualSharedBundle` array per type.
+  - A **root** file can contain imports of multiple types, just make sure to add an object in the `manualSharedBundle` array per type.
 - **split** (optional) - splits the manual bundle into x bundles. 
   - We've found that, for very large bundles, splitting them can improve measurements like CHR (cache hit ratio), as a smaller bundle is invalidated for a given change. 
 - **loadedBy** (optional) - Narrows the scope of what bundles can reference your MSB (Manual Shared Bundle).
   - This is useful in the case where your MSB is used by asynchronous modules. Specifying the `loadedBy` field with those asynchronous modules ensures that the MSB's load and execution time will in fact be deferred. Parcel will instead duplicate the asset(s) required by any bundles not included in `loadedBy`.
+
+
+
+#### BE CAREFUL 
+
+This feature will overwrite any automatic code splitting parcel does, and can cause unintended load-order issues as it maps on your **entire** code base, **including** `/node_modules`. Be mindful of the globs you use, only specify 1 bundle per file type, and we recommend you specify a **root** file. 

--- a/src/features/code-splitting.md
+++ b/src/features/code-splitting.md
@@ -239,7 +239,7 @@ Parcel automatically splits out commonly used modules into "shared bundles" and 
 
 These scenarios include but are not limited to...
 
-- Porting over your config from another build tool or bundler to parcel
+- Porting over your config from another build tool or bundler to Parcel
 - Reducing your HTTP requests without duplicating assets, in favor of over-fetching
   - We've found over-fetching and loading fewer bundles overall can greatly benefit measurements like TTI, especially for very large projects
 - Creating an optimized shared bundle for a specific route or set of modules
@@ -259,6 +259,7 @@ As of this writing, MSBs, or Manual Shared Bundles can be specified via `package
         "assets": ["**/*"],
         "loadedBy": ["async1.js", "async2.js"],
         "types": ["js"],
+        "split": 3
       },
     ],
   },
@@ -277,5 +278,7 @@ The optional parameters are as follows:
 - **assets** (required) - glob for Parcel to match on. Files that match the glob will be placed into a singular bundle, and deduplicated across the project unless otherwise specified. If no `root` is specified, Parcel attempts to match the glob **globally**.
 - **types** (optional) - Limits globs to only match on a certain type. This field must be set if your `root` file contains multiple types or if the glob can match different types, as a bundle can only contain assets of the same type.
   - A **root** file can contain imports of multiple types, just make sure to add an object in the `unstable_manualSharedBundle` array per type.
+- **split** (optional) - splits the manual bundle into x bundles. 
+  - We've found that, for very large bundles, splitting them can improve measurements like CHR (cache hit ratio), as a smaller bundle is invalidated for a given change. 
 - **loadedBy** (optional) - Narrows the scope of what bundles can reference your MSB (Manual Shared Bundle).
   - This is useful in the case where your MSB is used by asynchronous modules. Specifying the `loadedBy` field with those asynchronous modules ensures that the MSB's load and execution time will in fact be deferred. Parcel will instead duplicate the asset(s) required by any bundles not included in `loadedBy`.


### PR DESCRIPTION
Adds documentation on how to use the `manualSharedBundles` config option for the `DefaultBundler`. Includes some common reasons why a project may benefit from MSB (manual Shared Bundles), as well as a basic example of how to add config to your `package.json`

This PR should be merged once the [Source Bundles Property PR](https://github.com/parcel-bundler/parcel/pull/9294) is merged. That PR renames `parentAsset` to `root`, the property that specifies what file should be targeted by the `assets` glob. 

It also adds a `loadedBy` optional config, which allows users to specify bundleRoots that will use this MSB (manual shared bundle)
## Notes
Note that "display rich diff" in Github does not support all formatting used, here's a screen grab of what the page will look like: 
 
<img width="536" alt="experimental_msb_blurb" src="https://github.com/parcel-bundler/website/assets/29166446/7a168faf-9918-4dcb-b66e-6d4f0c57d78d">