### PR TITLE
Add watch-dir option

### DIFF
--- a/src/features/cli.md
+++ b/src/features/cli.md
@@ -99,7 +99,7 @@ These parameters are supported by all Parcel commands.
 | Format              | Description                                                                                                                                |
 | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
 | `-p, --port <port>` | The port for the dev server and HMR (the default port is `process.env.PORT` or 1234). See [Dev server](/features/development/#dev-server). |
-| `--host <host>`     | Sets the host to listen on, defaults to listening on all interfaces                                                                        |
+| `--host <host>`     | Sets the host to listen on, defaults to listening on all interfaces.                                                                       |
 | `--https`           | Runs the dev server and HMR server over [HTTPS](/features/development/#https).                                                             |
 | `--cert <path>`     | Path to a certificate to use. See [HTTPS](/features/development/#https).                                                                   |
 | `--key <path>`      | Path to a private key to use. See [HTTPS](/features/development/#https).                                                                   |
@@ -107,6 +107,7 @@ These parameters are supported by all Parcel commands.
 | `--hmr-port <port>` | The port for the HMR server (defaults to the dev server's port). See [Hot reloading](/features/development/#hot-reloading).                |
 | `--hmr-host <host>` | The host for the HMR server (defaults to the dev server's host). See [Hot reloading](/features/development/#hot-reloading).                |
 | `--no-autoinstall`  | Disables [auto install](/features/development/#auto-install).                                                                              |
+| `--watch-dir`       | Set the root watch directory. Useful for monorepos that have lockfiles in sub-projects.                                                    |
 | `--watch-for-stdin` | Stop Parcel once stdin is closed.                                                                                                          |
 
 ### Parameters specific to `serve`


### PR DESCRIPTION
I'm not sure if docs are auto-generated for CLI options. If not, here is info for *Configurable watch root* `--watch-dir` added in https://github.com/parcel-bundler/parcel/pull/9424 by @jondlm

