### PR TITLE
docs: add MDX 3 community plugin

### DIFF
--- a/src/languages/mdx.md
+++ b/src/languages/mdx.md
@@ -7,9 +7,11 @@ eleventyNavigation:
   order: 16
 ---
 
-[MDX](https://mdxjs.com) is a variant of [Markdown](https://daringfireball.net/projects/markdown/) that compiles to JSX, and supports embedding interactive components inside Markdown documents. Parcel supports MDX automatically using the `@parcel/transformer-mdx` plugin. When a `.mdx` file is detected, it will be installed into your project automatically.
+[MDX](https://mdxjs.com) is a variant of [Markdown](https://daringfireball.net/projects/markdown/) that compiles to JSX, and supports embedding interactive components inside Markdown documents.
 
-## Example usage
+## MDX v1 usage
+
+Parcel supports MDX v1 automatically using the `@parcel/transformer-mdx` plugin. When a `.mdx` file is detected, it will be installed into your project automatically.
 
 First, install `@mdx-js/react`. This is needed to render MDX files as React components.
 
@@ -41,3 +43,32 @@ This is a pretty cool MDX file.
 
 {% endsamplefile %}
 {% endsample %}
+
+## MDX v3 usage
+
+If you're using MDX v3, community plugin [`parcel-transformer-mdx`][1] is recommended, Babel & TypeScript configuration can be loaded automatically.
+
+### Installation
+
+```shell
+npm i @parcel/config-default parcel-transformer-mdx -D
+```
+
+### Configuration
+
+{% sample %}
+{% samplefile ".parcelrc" %}
+
+```json
+{
+    "extends": "@parcel/config-default",
+    "transformers": {
+        "*.{md,mdx}": ["parcel-transformer-mdx"]
+    }
+}
+```
+
+{% endsamplefile %}
+{% endsample %}
+
+[1]: https://img.shields.io/librariesio/github/EasyWebApp/Parcel-transformer-MDX.svg

--- a/src/languages/mdx.md
+++ b/src/languages/mdx.md
@@ -25,7 +25,7 @@ Then, you can import a `.mdx` file into your JavaScript and render it using Reac
 {% samplefile "app.js" %}
 
 ```js
-import Hello from './hello.mdx';
+import Hello from "./hello.mdx";
 
 export function App() {
   return <Hello />;
@@ -46,7 +46,7 @@ This is a pretty cool MDX file.
 
 ## MDX v3 usage
 
-If you're using MDX v3, community plugin [`parcel-transformer-mdx`][1] is recommended, Babel & TypeScript configuration can be loaded automatically.
+If you're using MDX v3, you can use the community plugin [`parcel-transformer-mdx`](https://www.npmjs.com/package/parcel-transformer-mdx).
 
 ### Installation
 
@@ -61,10 +61,10 @@ npm i @parcel/config-default parcel-transformer-mdx -D
 
 ```json
 {
-    "extends": "@parcel/config-default",
-    "transformers": {
-        "*.{md,mdx}": ["parcel-transformer-mdx"]
-    }
+  "extends": "@parcel/config-default",
+  "transformers": {
+    "*.{md,mdx}": ["parcel-transformer-mdx"]
+  }
 }
 ```
 


### PR DESCRIPTION
## Summary

I publish a [Parcel 2 transformer plugin for MDX 3][1], which has been used in [the document web-site of WebCell Bootstrap components suite][2].

## Related issues

1. fix parcel-bundler/parcel#3357
2. fix parcel-bundler/parcel#7934

[1]: https://github.com/EasyWebApp/Parcel-transformer-MDX
[2]: https://github.com/EasyWebApp/BootCell-document