### PR TITLE
Add helix's atomic_save option to the development documentation

### DIFF
--- a/src/features/development.md
+++ b/src/features/development.md
@@ -172,7 +172,7 @@ To disable safe write, use the options provided below:
 - Vim: add `:set backupcopy=yes` to your settings.
 - WebStorm: uncheck `Use "safe write"` in Preferences > Appearance & Behavior > System Settings.
 - vis: add `:set savemethod inplace` to your settings.
-- Helix: add `atomic_save = false` to your `[editor]` settings
+- Helix: add `atomic-save = false` to your `[editor]` settings
 
 ##### Linux: No space left on device
 

--- a/src/features/development.md
+++ b/src/features/development.md
@@ -172,6 +172,7 @@ To disable safe write, use the options provided below:
 - Vim: add `:set backupcopy=yes` to your settings.
 - WebStorm: uncheck `Use "safe write"` in Preferences > Appearance & Behavior > System Settings.
 - vis: add `:set savemethod inplace` to your settings.
+- Helix: add `atomic_save = false` to your `[editor]` settings
 
 ##### Linux: No space left on device
 


### PR DESCRIPTION
This PR documents Helix's `atomic_save` option in the developer documentation, since it's another editor that implements the "safe write" strategy.

Currently waiting on helix-editor/helix#13656